### PR TITLE
Add service config and improve startup handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Mini OS
+
+This repository contains a simple menu-based interface for a Raspberry Pi with an ST7735-based LCD display.
+
+## Running as a `systemd` Service
+
+1. Copy `mini_os.service` to `/etc/systemd/system/` (or `~/.config/systemd/user/` for a user service).
+2. Adjust the paths in the unit file if you place the project somewhere other than `/opt/mini_os`.
+3. Reload systemd and enable the service:
+   ```bash
+   sudo systemctl daemon-reload
+   sudo systemctl enable mini_os.service
+   sudo systemctl start mini_os.service
+   ```
+
+The service definition will start the program on boot and restart it automatically if it exits unexpectedly.

--- a/main.py
+++ b/main.py
@@ -125,6 +125,10 @@ def button_event_handler(channel):
     current_time = time.time()
     pin_name = next((name for name, num in BUTTON_PINS.items() if num == channel), f"Unknown Pin {channel}")
 
+    # If the menu hasn't been initialized yet, ignore events
+    if menu_instance is None:
+        return
+
     # Simple debounce to prevent multiple triggers from one physical press
     if current_time - last_event_time[pin_name] < 0.2: # 200ms debounce time
         return
@@ -158,11 +162,10 @@ def button_event_handler(channel):
     last_event_time[pin_name] = current_time
 
 
-# Attach event detection to all desired pins
-for pin_name, pin_num in BUTTON_PINS.items():
-    # Detect both rising and falling edges to track press/release for robustness
-    GPIO.add_event_detect(pin_num, GPIO.BOTH, callback=button_event_handler, bouncetime=100) 
-    # bouncetime in ms helps filter out noise.
+
+# Global menu instance will be created in the main block.  Defining it here
+# prevents NameError in callbacks triggered before initialization.
+menu_instance = None
 
 
 # --- Program Launchers (Placeholders for your applications) ---
@@ -248,6 +251,12 @@ def handle_menu_selection(selection):
 if __name__ == "__main__":
     menu_items = ["Run Program 1", "Run Program 2", "Show Info", "Shutdown"]
     menu_instance = Menu(menu_items)
+
+    # Attach event detection to all desired pins after the menu is ready
+    for pin_name, pin_num in BUTTON_PINS.items():
+        # Detect both rising and falling edges to track press/release for robustness
+        GPIO.add_event_detect(pin_num, GPIO.BOTH, callback=button_event_handler, bouncetime=100)
+        # bouncetime in ms helps filter out noise.
 
     try:
         # Initialize backlight control

--- a/mini_os.service
+++ b/mini_os.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Mini OS Menu Service
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 /opt/mini_os/main.py
+WorkingDirectory=/opt/mini_os
+Restart=always
+User=pi
+Group=pi
+Environment=PYTHONUNBUFFERED=1
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add a `systemd` unit file and README instructions for enabling service
- ensure menu callback is safe before the menu is initialized
- move GPIO event setup into the main block

## Testing
- `flake8 main.py`
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68487fb95c30832f913dc0d863dacadf