### PR TITLE
Add brightness settings screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains a simple menu-based interface for a Raspberry Pi with an ST7735-based LCD display.
 
+The interface now includes a basic Settings screen where you can adjust the LCD backlight brightness using the joystick.
+
 ## Pin Assignments
 
 Mini OS uses BCM GPIO numbers. Connect the Waveshare 1.44" ST7735 display and buttons as follows:


### PR DESCRIPTION
## Summary
- add basic settings screen with brightness control
- start PWM backlight control and expose brightness adjustments
- document new settings screen in README

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68488c3fcd90832f9796f47868dc5abc