### PR TITLE
Add system monitor program

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains a simple menu-based interface for a Raspberry Pi with an ST7735-based LCD display.
 
-The interface now includes a basic Settings screen where you can adjust the LCD backlight brightness using the joystick. It also provides a menu option to briefly display the current date and time.
+The interface now includes a basic Settings screen where you can adjust the LCD backlight brightness using the joystick. It also provides menu options to briefly display the current date and time and a simple system monitor showing CPU temperature, load and memory usage.
 
 ## Setup on Raspberry Pi OS Lite (32-bit)
 


### PR DESCRIPTION
## Summary
- add a simple system monitor program displaying CPU temperature, load and memory usage
- integrate System Monitor into main menu
- document the new feature in README

## Testing
- `python3 -m py_compile main.py`
- `python3 main.py` *(fails: ModuleNotFoundError: No module named 'RPi')*

------
https://chatgpt.com/codex/tasks/task_e_6848b347a9d8832fa5cb280857dc8a43