### PR TITLE
Add reboot menu option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains a simple menu-based interface for a Raspberry Pi with an ST7735-based LCD display.
 
-The interface now includes a basic Settings screen where you can adjust the LCD backlight brightness using the joystick. It also provides menu options to briefly display the current date and time, a simple system monitor showing CPU temperature, load and memory usage, and a network info screen showing the current IP address and Wi-Fi SSID.
+The interface now includes a basic Settings screen where you can adjust the LCD backlight brightness using the joystick. It also provides menu options to briefly display the current date and time, a simple system monitor showing CPU temperature, load and memory usage, and a network info screen showing the current IP address and Wi-Fi SSID. A Shutdown and Reboot option are available for safely powering off or restarting the Pi.
 
 ## Setup on Raspberry Pi OS Lite (32-bit)
 

--- a/main.py
+++ b/main.py
@@ -223,7 +223,7 @@ def button_event_handler(channel):
             elif pin_name == "JOY_PRESS":
                 handle_menu_selection(menu_instance.get_selected_item())
             elif pin_name == "KEY1":
-                if menu_instance.get_selected_item() != "Shutdown":
+                if menu_instance.selected_item != len(menu_instance.items) - 1:
                     menu_instance.selected_item = len(menu_instance.items) - 1
                     menu_instance.draw()
             elif pin_name == "KEY2":
@@ -694,6 +694,7 @@ def show_main_menu():
         "Show Info",
         "Settings",
         "Shutdown",
+        "Reboot",
     ]
     menu_instance.selected_item = 0
     menu_instance.view_start = 0
@@ -742,6 +743,12 @@ def handle_menu_selection(selection):
         # If shutdown fails or doesn't happen fast enough, script might continue.
         # For robustness, you might want to exit the script after the poweroff command.
         exit() # Exit the Python script as OS is shutting down
+    elif selection == "Reboot":
+        menu_instance.display_message_screen("System", "Rebooting...", delay=2)
+        print("Rebooting now via systemctl reboot.")
+        # Perform actual reboot. Needs proper permissions similar to shutdown.
+        subprocess.run(["sudo", "reboot"], check=True)
+        exit()  # Exit as the system is rebooting
     
     # After any program finishes, redraw the menu
     menu_instance.draw()


### PR DESCRIPTION
## Summary
- add a Reboot entry at the bottom of the main menu
- trigger a system reboot when selected
- make KEY1 shortcut jump to the last menu item generically
- document reboot capability in the README

## Testing
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6849073b7104832f82a4444243a43f30