### PR TITLE
Add Gallery image viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains a simple menu-based interface for a Raspberry Pi with a
 The interface now includes a basic Settings screen where you can adjust the LCD backlight brightness using the joystick. It also provides menu options to briefly display the current date and time, a simple system monitor showing CPU temperature, load and memory usage, and a network info screen showing the current IP address and Wi-Fi SSID.
 
 Two small games are included: a reaction-based **Button Game** and a memory challenge called **Launch Codes**. Both can be started from the main menu and make use of the three buttons and joystick directions for input.
+A simple **Gallery** viewer lets you browse 128x128 images stored in the `images` directory. Use the joystick left/right to switch pictures and press it to exit.
 
 ## Setup on Raspberry Pi OS Lite (32-bit)
 


### PR DESCRIPTION
## Summary
- create `images` directory for 128x128 pictures
- add Gallery viewer with left/right navigation and exit with joystick press
- integrate Gallery into main menu
- mention Gallery in README

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_684919e2a0e4832fa20de6fd43fc9f50