### PR TITLE
Remove cs_high option from SPI init

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ BL_PIN = 24   # Backlight pin, GPIO 24
 
 # SPI communication setup (port=0, device=0 corresponds to SPI0 CE0/GPIO 8)
 # Speed can be up to 60MHz for ST7735S 
-serial_interface = spi(port=0, device=0, cs_high=False,
+serial_interface = spi(port=0, device=0,
                        gpio_DC=DC_PIN, gpio_RST=RST_PIN,
                        speed_hz=16000000) # 16MHz is a good speed. Max is 60MHz.
 


### PR DESCRIPTION
## Summary
- remove `cs_high=False` from SPI initialization since it is ignored on newer kernels

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68491ce9e6c4832f9b3f9b0685fa0311