### PR TITLE
Add Soft Reboot option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains a simple menu-based interface for a Raspberry Pi with an ST7735-based LCD display.
 
-The interface now includes a basic Settings screen where you can adjust the LCD backlight brightness using the joystick. It also provides menu options to briefly display the current date and time, a simple system monitor showing CPU temperature, load and memory usage, and a network info screen showing the current IP address and Wi-Fi SSID. A Shutdown and Reboot option are available for safely powering off or restarting the Pi. An "Update Mini-OS" entry pulls the latest code with `git pull`.
+The interface now includes a basic Settings screen where you can adjust the LCD backlight brightness using the joystick. It also provides menu options to briefly display the current date and time, a simple system monitor showing CPU temperature, load and memory usage, and a network info screen showing the current IP address and Wi-Fi SSID. Shutdown, Reboot, and Soft Reboot options are available for safely powering off, restarting the Pi, or just restarting the Mini OS service. An "Update Mini-OS" entry pulls the latest code with `git pull`.
 
 Two small games are included: a reaction-based **Button Game** and a memory challenge called **Launch Codes**. Both can be started from the main menu and make use of the three buttons and joystick directions for input.
 

--- a/main.py
+++ b/main.py
@@ -864,6 +864,7 @@ def show_main_menu():
         "Settings",
         "Shutdown",
         "Reboot",
+        "Soft Reboot",
     ]
     menu_instance.selected_item = 0
     menu_instance.view_start = 0
@@ -921,6 +922,12 @@ def handle_menu_selection(selection):
         # Perform actual reboot. Needs proper permissions similar to shutdown.
         subprocess.run(["sudo", "reboot"], check=True)
         exit()  # Exit as the system is rebooting
+    elif selection == "Soft Reboot":
+        menu_instance.display_message_screen("System", "Restarting Mini-OS...", delay=2)
+        print("Restarting mini_os.service via systemctl restart.")
+        # Restart only the service running this script
+        subprocess.run(["sudo", "systemctl", "restart", "mini_os.service"], check=True)
+        exit()
     
     # After any program finishes, redraw the menu
     menu_instance.draw()


### PR DESCRIPTION
## Summary
- allow restarting only the mini_os service from the menu
- document new Soft Reboot option

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_684925ff2dd8832f81c4f9a28d529275