### PR TITLE
Add Update and Restart option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains a simple menu-based interface for a Raspberry Pi with an ST7735-based LCD display.
 
-The interface now includes a basic Settings screen where you can adjust the LCD backlight brightness using the joystick. It also provides menu options to briefly display the current date and time, a simple system monitor showing CPU temperature, load and memory usage, and a network info screen showing the current IP address and Wi-Fi SSID. Shutdown, Reboot, and Soft Reboot options are available for safely powering off, restarting the Pi, or just restarting the Mini OS service. An "Update Mini-OS" entry pulls the latest code with `git pull`.
+The interface now includes a basic Settings screen where you can adjust the LCD backlight brightness using the joystick. It also provides menu options to briefly display the current date and time, a simple system monitor showing CPU temperature, load and memory usage, and a network info screen showing the current IP address and Wi-Fi SSID. Shutdown, Reboot, and Soft Reboot options are available for safely powering off, restarting the Pi, or just restarting the Mini OS service. An "Update Mini-OS" entry pulls the latest code with `git pull`. A new "Update and Restart" option pulls the code and restarts the service so the update takes effect.
 
 Two small games are included: a reaction-based **Button Game** and a memory challenge called **Launch Codes**. Both can be started from the main menu and make use of the three buttons and joystick directions for input.
 

--- a/main.py
+++ b/main.py
@@ -361,6 +361,14 @@ def run_git_pull():
     menu_instance.clear_display()
 
 
+def update_and_restart():
+    """Update the code then restart the mini_os service."""
+    run_git_pull()
+    menu_instance.display_message_screen("System", "Restarting Mini-OS...", delay=2)
+    subprocess.run(["sudo", "systemctl", "restart", "mini_os.service"], check=True)
+    exit()
+
+
 def start_image_gallery():
     """Load images from the images directory and display the first one."""
     global gallery_images, gallery_index
@@ -955,6 +963,7 @@ def show_main_menu():
     menu_instance.max_visible_items = 6
     menu_instance.items = [
         "Update Mini-OS",
+        "Update and Restart",
         "Button Game",
         "Launch Codes",
         "Typer",
@@ -988,6 +997,8 @@ def handle_menu_selection(selection):
     print(f"Selected: {selection}") # This output goes to journalctl
     if selection == "Update Mini-OS":
         run_git_pull()
+    elif selection == "Update and Restart":
+        update_and_restart()
     elif selection == "Button Game":
         start_button_game()
         return


### PR DESCRIPTION
## Summary
- allow mini OS to update itself and restart via new `Update and Restart` menu entry
- document the new behaviour

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6849292cb7b8832f98acba8cce98b6d3