### PR TITLE
Add cycling keyboard modes and spacebar for Typer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Two small games are included: a reaction-based **Button Game** and a memory chal
 
 An **Image Gallery** viewer is also included. Create an `images/` directory (the program will create it if missing) and place your 128x128 PNG or JPEG files there. When started from the menu you can flip through the pictures using the joystick left and right, and press the joystick in to return to the main menu.
 
+The **Typer** program provides an onscreen keyboard for entering text. Use the joystick to move the highlight and press it to select a key. Press **KEY1** to cycle between uppercase, lowercase and punctuation layouts. **KEY2** deletes the last character and **KEY3** exits the program. A long space bar is available on the bottom row and is selected just like any other key.
+
 ## Setup on Raspberry Pi OS Lite (32-bit)
 
 Install the required packages and enable the SPI interface:

--- a/main.py
+++ b/main.py
@@ -840,12 +840,31 @@ def handle_launch_input(pin_name):
 typer_text = ""
 typer_row = 1  # Start with the A row
 typer_col = 0  # Column for A
+keyboard_state = 0  # 0=upper,1=lower,2=punct
 
-KEY_LAYOUT = [
+KEYBOARD_UPPER = [
     list("QWERTYUIOP"),
     list("ASDFGHJKL"),
     list("ZXCVBNM"),
+    [" "]  # Space bar
 ]
+
+KEYBOARD_LOWER = [
+    list("qwertyuiop"),
+    list("asdfghjkl"),
+    list("zxcvbnm"),
+    [" "]
+]
+
+KEYBOARD_PUNCT = [
+    list("!@#$%^&*()"),
+    list("-_=+[]{}"),
+    list(";:'\",.<>/?"),
+    [" "]
+]
+
+KEY_LAYOUTS = [KEYBOARD_UPPER, KEYBOARD_LOWER, KEYBOARD_PUNCT]
+KEY_LAYOUT = KEY_LAYOUTS[keyboard_state]
 
 
 def draw_typer_screen():
@@ -869,11 +888,16 @@ def draw_typer_screen():
     row_h = (DISPLAY_HEIGHT - kb_y) // len(KEY_LAYOUT)
     key_w = DISPLAY_WIDTH // 10
     for r, row in enumerate(KEY_LAYOUT):
-        offset_x = (DISPLAY_WIDTH - len(row) * key_w) // 2
+        if r == len(KEY_LAYOUT) - 1 and len(row) == 1:
+            offset_x = 5
+            this_key_w = DISPLAY_WIDTH - offset_x * 2
+        else:
+            offset_x = (DISPLAY_WIDTH - len(row) * key_w) // 2
+            this_key_w = key_w
         for c, ch in enumerate(row):
-            x = offset_x + c * key_w
+            x = offset_x + c * this_key_w
             y = kb_y + r * row_h
-            rect = (x + 1, y + 1, x + key_w - 2, y + row_h - 2)
+            rect = (x + 1, y + 1, x + this_key_w - 2, y + row_h - 2)
             if r == typer_row and c == typer_col:
                 draw.rectangle(rect, fill=(0, 255, 0))
                 text_color = (0, 0, 0)
@@ -881,28 +905,29 @@ def draw_typer_screen():
                 draw.rectangle(rect, outline=(255, 255, 255))
                 text_color = (255, 255, 255)
             bbox = draw.textbbox((0, 0), ch, font=font_small)
-            tx = x + (key_w - (bbox[2] - bbox[0])) // 2
+            tx = x + (this_key_w - (bbox[2] - bbox[0])) // 2
             ty = y + (row_h - (bbox[3] - bbox[1])) // 2
             draw.text((tx, ty), ch, font=font_small, fill=text_color)
 
-    draw.text((5, DISPLAY_HEIGHT - 10), "1=Space 2=Back 3=Exit", font=font_small, fill=(0, 255, 255))
     thread_safe_display(img)
 
 
 def start_typer():
     """Initialize the Typer program."""
-    global typer_text, typer_row, typer_col
+    global typer_text, typer_row, typer_col, keyboard_state, KEY_LAYOUT
     stop_scrolling()
     typer_text = ""
     typer_row = 1
     typer_col = 0
+    keyboard_state = 0
+    KEY_LAYOUT = KEY_LAYOUTS[keyboard_state]
     menu_instance.current_screen = "typer"
     draw_typer_screen()
 
 
 def handle_typer_input(pin_name):
     """Handle joystick and button input for Typer."""
-    global typer_row, typer_col, typer_text
+    global typer_row, typer_col, typer_text, keyboard_state, KEY_LAYOUT
     if pin_name == "JOY_LEFT" and typer_col > 0:
         typer_col -= 1
     elif pin_name == "JOY_RIGHT" and typer_col < len(KEY_LAYOUT[typer_row]) - 1:
@@ -916,7 +941,10 @@ def handle_typer_input(pin_name):
     elif pin_name == "JOY_PRESS":
         typer_text += KEY_LAYOUT[typer_row][typer_col]
     elif pin_name == "KEY1":
-        typer_text += " "
+        keyboard_state = (keyboard_state + 1) % len(KEY_LAYOUTS)
+        KEY_LAYOUT = KEY_LAYOUTS[keyboard_state]
+        typer_row = min(typer_row, len(KEY_LAYOUT) - 1)
+        typer_col = min(typer_col, len(KEY_LAYOUT[typer_row]) - 1)
     elif pin_name == "KEY2":
         typer_text = typer_text[:-1]
     elif pin_name == "KEY3":


### PR DESCRIPTION
## Summary
- update Typer to support uppercase, lowercase and punctuation layouts
- add selectable long space bar on the bottom row
- cycle keyboard layouts with KEY1 instead of inserting a space
- document Typer usage in README

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_684929ce65f0832f851a1d5dc223d8ae