### PR TITLE
Remove open hint from NYT story view

### DIFF
--- a/main.py
+++ b/main.py
@@ -490,7 +490,8 @@ def draw_story_detail(index):
         for line in story_lines:
             draw.text((5, y), line, font=font_small, fill=(255, 255, 255))
             y += story_line_h
-        draw.text((5, DISPLAY_HEIGHT - 10), "1=Open 3=Back", font=font_small, fill=(0, 255, 255))
+        # Only show the back hint; opening a link isn't supported here
+        draw.text((5, DISPLAY_HEIGHT - 10), "3=Back", font=font_small, fill=(0, 255, 255))
         device.display(img)
 
     story_render = render


### PR DESCRIPTION
## Summary
- don't show `1=Open` hint when viewing NYT story details

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68492b4842f4832fbda3ee5c71c0b45e