### PR TITLE
Revise menu layout and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This repository contains a simple menu-based interface for a Raspberry Pi with an ST7735-based LCD display.
 
-The interface now includes a basic Settings screen where you can adjust the LCD backlight brightness using the joystick. It also provides menu options to briefly display the current date and time, a simple system monitor showing CPU temperature, load and memory usage, and a network info screen showing the current IP address and Wi-Fi SSID. Shutdown, Reboot, and Soft Reboot options are available for safely powering off, restarting the Pi, or just restarting the Mini OS service. An "Update Mini-OS" entry pulls the latest code with `git pull`. A new "Update and Restart" option pulls the code and restarts the service so the update takes effect.
+The interface now includes a basic Settings screen where you can adjust the LCD backlight brightness using the joystick. It also provides menu options to briefly display the current date and time, a simple system monitor showing CPU temperature, load and memory usage, and a network info screen showing the current IP address and Wi-Fi SSID. Shutdown and Reboot options are available for safely powering off or restarting the Pi. An "Update and Restart" option pulls the latest code and restarts the service so the update takes effect.
 
-Two small games are included: a reaction-based **Button Game** and a memory challenge called **Launch Codes**. Both can be started from the main menu and make use of the three buttons and joystick directions for input.
+Two small games are included: a reaction-based **Button Game** and a memory challenge called **Launch Codes**. They can be started from the **Games** submenu and make use of the three buttons and joystick directions for input.
 
 An **Image Gallery** viewer is also included. Create an `images/` directory (the program will create it if missing) and place your 128x128 PNG or JPEG files there. When started from the menu you can flip through the pictures using the joystick left and right, and press the joystick in to return to the main menu.
 

--- a/main.py
+++ b/main.py
@@ -294,6 +294,15 @@ def button_event_handler(channel):
                     connect_to_wifi(selection)
             elif pin_name == "KEY1":
                 show_settings_menu()
+        elif menu_instance.current_screen == "games":
+            if pin_name == "JOY_UP":
+                menu_instance.navigate("up")
+            elif pin_name == "JOY_DOWN":
+                menu_instance.navigate("down")
+            elif pin_name == "JOY_PRESS":
+                handle_games_selection(menu_instance.get_selected_item())
+            elif pin_name == "KEY1":
+                show_main_menu()
         elif menu_instance.current_screen == "nyt_headline":
             if pin_name == "JOY_UP" and current_story_index > 0:
                 draw_headline(current_story_index - 1)
@@ -986,14 +995,33 @@ def show_settings_menu():
     menu_instance.draw()
 
 
+def show_games_menu():
+    stop_scrolling()
+    menu_instance.max_visible_items = 6
+    menu_instance.items = ["Button Game", "Launch Codes", "Back"]
+    menu_instance.selected_item = 0
+    menu_instance.view_start = 0
+    menu_instance.current_screen = "games"
+    menu_instance.draw()
+
+
+def handle_games_selection(selection):
+    if selection == "Button Game":
+        start_button_game()
+        return
+    elif selection == "Launch Codes":
+        start_launch_codes()
+        return
+    elif selection == "Back":
+        show_main_menu()
+
+
 def show_main_menu():
     stop_scrolling()
     menu_instance.max_visible_items = 6
     menu_instance.items = [
-        "Update Mini-OS",
         "Update and Restart",
-        "Button Game",
-        "Launch Codes",
+        "Games",
         "Typer",
         "Image Gallery",
         "System Monitor",
@@ -1004,7 +1032,6 @@ def show_main_menu():
         "Settings",
         "Shutdown",
         "Reboot",
-        "Soft Reboot",
     ]
     menu_instance.selected_item = 0
     menu_instance.view_start = 0
@@ -1023,16 +1050,10 @@ def handle_settings_selection(selection):
 
 def handle_menu_selection(selection):
     print(f"Selected: {selection}") # This output goes to journalctl
-    if selection == "Update Mini-OS":
-        run_git_pull()
-    elif selection == "Update and Restart":
+    if selection == "Update and Restart":
         update_and_restart()
-    elif selection == "Button Game":
-        start_button_game()
-        return
-    elif selection == "Launch Codes":
-        start_launch_codes()
-        return
+    elif selection == "Games":
+        show_games_menu()
     elif selection == "Typer":
         start_typer()
     elif selection == "Image Gallery":
@@ -1066,12 +1087,6 @@ def handle_menu_selection(selection):
         # Perform actual reboot. Needs proper permissions similar to shutdown.
         subprocess.run(["sudo", "reboot"], check=True)
         exit()  # Exit as the system is rebooting
-    elif selection == "Soft Reboot":
-        menu_instance.display_message_screen("System", "Restarting Mini-OS...", delay=2)
-        print("Restarting mini_os.service via systemctl restart.")
-        # Restart only the service running this script
-        subprocess.run(["sudo", "systemctl", "restart", "mini_os.service"], check=True)
-        exit()
     
     # After any program finishes, redraw the menu
     menu_instance.draw()


### PR DESCRIPTION
## Summary
- add a `Games` submenu and move Button Game and Launch Codes there
- drop `Update Mini-OS` and `Soft Reboot` menu entries
- update README description

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68492c26f298832fb9998e903c89b63b