### PR TITLE
Fix Typer menu return

### DIFF
--- a/main.py
+++ b/main.py
@@ -1042,6 +1042,7 @@ def handle_menu_selection(selection):
         return
     elif selection == "Typer":
         start_typer()
+        return
     elif selection == "Image Gallery":
         start_image_gallery()
         return


### PR DESCRIPTION
## Summary
- keep the screen on Typer until user exits

## Testing
- `python3 -m py_compile main.py`
- `python3 main.py` *(fails: No module named 'RPi')*

------
https://chatgpt.com/codex/tasks/task_e_68492d7cf364832fa53e7a47b5bad928