### PR TITLE
Enhance system monitor metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains a simple menu-based interface for a Raspberry Pi with an ST7735-based LCD display.
 
-The interface now includes a basic Settings screen where you can adjust the LCD backlight brightness using the joystick. It also provides menu options to briefly display the current date and time, a simple system monitor showing CPU temperature, load and memory usage, and a network info screen showing the current IP address and Wi-Fi SSID. Shutdown and Reboot options are available for safely powering off or restarting the Pi. An "Update and Restart" option pulls the latest code and restarts the service so the update takes effect.
+The interface now includes a basic Settings screen where you can adjust the LCD backlight brightness using the joystick. It also provides menu options to briefly display the current date and time, a system monitor showing CPU temperature, load, frequency, memory and disk usage, and a network info screen with the current IP address and Wi-Fi SSID. Shutdown and Reboot options are available for safely powering off or restarting the Pi. An "Update and Restart" option pulls the latest code and restarts the service so the update takes effect.
 
 Two small games are included: a reaction-based **Button Game** and a memory challenge called **Launch Codes**. They can be started from the **Games** submenu and make use of the three buttons and joystick directions for input.
 

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ import random
 import threading
 import requests
 import webbrowser
+import shutil
 
 # Luma.lcd imports and setup
 from luma.core.interface.serial import spi
@@ -594,6 +595,20 @@ def run_system_monitor(duration=10):
         except Exception:
             load = 0.0
 
+        # Current CPU frequency in MHz
+        try:
+            with open("/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq") as f:
+                cpu_freq = int(f.read().strip()) / 1000  # kHz -> MHz
+        except Exception:
+            cpu_freq = None
+
+        # Disk usage for root filesystem
+        try:
+            usage = shutil.disk_usage("/")
+            disk_str = f"{usage.used // (1024*1024)}/{usage.total // (1024*1024)}MB"
+        except Exception:
+            disk_str = "N/A"
+
         # Memory usage from /proc/meminfo
         mem_total = 0
         mem_available = 0
@@ -617,7 +632,12 @@ def run_system_monitor(duration=10):
         draw.text((5, 5), "System Monitor", font=font_large, fill=(255, 255, 0))
         draw.text((5, 25), f"Temp: {temp}C", font=font_medium, fill=(255, 255, 255))
         draw.text((5, 40), f"Load: {load:.2f}", font=font_medium, fill=(255, 255, 255))
-        draw.text((5, 55), f"Mem: {mem_str}", font=font_medium, fill=(255, 255, 255))
+        if cpu_freq is not None:
+            draw.text((5, 55), f"Freq: {cpu_freq:.0f}MHz", font=font_medium, fill=(255, 255, 255))
+        else:
+            draw.text((5, 55), "Freq: N/A", font=font_medium, fill=(255, 255, 255))
+        draw.text((5, 70), f"Mem: {mem_str}", font=font_medium, fill=(255, 255, 255))
+        draw.text((5, 85), f"Disk: {disk_str}", font=font_medium, fill=(255, 255, 255))
         thread_safe_display(img)
         time.sleep(1)
     menu_instance.clear_display()


### PR DESCRIPTION
## Summary
- add CPU frequency and disk usage stats to system monitor
- mention the new metrics in README

## Testing
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6849313c9e18832f9a5f0d9db57fe51e