### PR TITLE
Update disk usage display

### DIFF
--- a/main.py
+++ b/main.py
@@ -606,7 +606,7 @@ def run_system_monitor(duration=10):
         # Disk usage for root filesystem
         try:
             usage = shutil.disk_usage("/")
-            disk_str = f"{usage.used // (1024*1024)}/{usage.total // (1024*1024)}MB"
+            disk_str = f"{usage.used // (1024**3)}/{usage.total // (1024**3)}GB"
         except Exception:
             disk_str = "N/A"
 


### PR DESCRIPTION
## Summary
- tweak disk usage display in the system monitor to show GB instead of MB

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_684933529878832fa7880ef7cfe99748