### PR TITLE
Fix Top Stories screen initialization

### DIFF
--- a/main.py
+++ b/main.py
@@ -1256,6 +1256,7 @@ def handle_menu_selection(selection):
         show_network_info()
     elif selection == "Top Stories":
         show_top_stories()
+        return
     elif selection == "Date & Time":
         show_date_time()
     elif selection == "Show Info":


### PR DESCRIPTION
## Summary
- return early after launching Top Stories

## Testing
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_684937713950832f888790ca3d8f0049