### PR TITLE
Add auto lowercase to Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Two small games are included: a reaction-based **Button Game** and a memory chal
 
 An **Image Gallery** viewer is also included. Create an `images/` directory (the program will create it if missing) and place your 128x128 PNG or JPEG files there. When started from the menu you can flip through the pictures using the joystick left and right, and press the joystick in to return to the main menu.
 
-The **Notes** program provides an onscreen keyboard for taking quick notes. Use the joystick to move the highlight and press it to select a key. Press **KEY1** to cycle between uppercase, lowercase and punctuation layouts. **KEY2** deletes the last character and **KEY3** saves the note and exits the program. Notes are stored in the `/notes` directory as `note1.txt`, `note2.txt`, and so on.
+The **Notes** program provides an onscreen keyboard for taking quick notes. Use the joystick to move the highlight and press it to select a key. When a new note is started the keyboard begins in uppercase mode and automatically switches to lowercase after the first letter is entered. Press **KEY1** to manually cycle between uppercase, lowercase and punctuation layouts. **KEY2** deletes the last character and **KEY3** saves the note and exits the program. Notes are stored in the `/notes` directory as `note1.txt`, `note2.txt`, and so on.
 
 ## Setup on Raspberry Pi OS Lite (32-bit)
 


### PR DESCRIPTION
## Summary
- start a new note in uppercase and automatically switch to lowercase after the first letter
- update README with new notes behaviour

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_684944625efc832f9499c3075c968033