### PR TITLE
Nest shutdown and reboot in settings menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains a simple menu-based interface for a Raspberry Pi with an ST7735-based LCD display.
 
-The interface now includes a Settings screen. A **Display** submenu lets you change the LCD backlight brightness, choose a different font and adjust the text size. Additional menu options briefly display the current date and time, a system monitor showing CPU temperature, load, frequency, memory and disk usage, and a network info screen with the current IP address and Wi-Fi SSID. Shutdown and Reboot options are available for safely powering off or restarting the Pi. An "Update and Restart" option pulls the latest code and restarts the service so the update takes effect.
+The interface now includes a Settings screen. A **Display** submenu lets you change the LCD backlight brightness, choose a different font and adjust the text size. Additional menu options briefly display the current date and time, a system monitor showing CPU temperature, load, frequency, memory and disk usage, and a network info screen with the current IP address and Wi-Fi SSID. Shutdown and Reboot options are available at the bottom of the Settings screen for safely powering off or restarting the Pi. An "Update and Restart" option pulls the latest code and restarts the service so the update takes effect.
 
 Two small games are included: a reaction-based **Button Game** and a memory challenge called **Launch Codes**. They can be started from the **Games** submenu and make use of the three buttons and joystick directions for input.
 

--- a/main.py
+++ b/main.py
@@ -1693,7 +1693,14 @@ def show_settings_menu():
     """Top-level settings menu."""
     stop_scrolling()
     menu_instance.max_visible_items = compute_max_visible_items(menu_instance.font)
-    menu_instance.items = ["Display", "Wi-Fi Setup", "Toggle Wi-Fi", "Back"]
+    menu_instance.items = [
+        "Display",
+        "Wi-Fi Setup",
+        "Toggle Wi-Fi",
+        "Shutdown",
+        "Reboot",
+        "Back",
+    ]
     menu_instance.selected_item = 0
     menu_instance.view_start = 0
     menu_instance.current_screen = "settings"
@@ -1848,8 +1855,6 @@ def show_main_menu():
         "Date & Time",
         "Show Info",
         "Settings",
-        "Shutdown",
-        "Reboot",
     ]
     menu_instance.selected_item = 0
     menu_instance.view_start = 0
@@ -1864,6 +1869,16 @@ def handle_settings_selection(selection):
         show_wifi_networks()
     elif selection == "Toggle Wi-Fi":
         toggle_wifi()
+    elif selection == "Shutdown":
+        menu_instance.display_message_screen("System", "Shutting down...", delay=2)
+        print("Shutting down now via systemctl poweroff.")
+        subprocess.run(["sudo", "poweroff"], check=True)
+        exit()
+    elif selection == "Reboot":
+        menu_instance.display_message_screen("System", "Rebooting...", delay=2)
+        print("Rebooting now via systemctl reboot.")
+        subprocess.run(["sudo", "reboot"], check=True)
+        exit()
     elif selection == "Back":
         show_main_menu()
 
@@ -1895,22 +1910,6 @@ def handle_menu_selection(selection):
         show_info()
     elif selection == "Settings":
         show_settings_menu()
-    elif selection == "Shutdown":
-        menu_instance.display_message_screen("System", "Shutting down...", delay=2)
-        print("Shutting down now via systemctl poweroff.")
-        # Perform actual shutdown. User running service needs permission for this.
-        # This typically means adding 'pi ALL=(ALL) NOPASSWD: /sbin/poweroff' to /etc/sudoers
-        # OR running the service as root (less secure, not recommended)
-        subprocess.run(["sudo", "poweroff"], check=True)
-        # If shutdown fails or doesn't happen fast enough, script might continue.
-        # For robustness, you might want to exit the script after the poweroff command.
-        exit() # Exit the Python script as OS is shutting down
-    elif selection == "Reboot":
-        menu_instance.display_message_screen("System", "Rebooting...", delay=2)
-        print("Rebooting now via systemctl reboot.")
-        # Perform actual reboot. Needs proper permissions similar to shutdown.
-        subprocess.run(["sudo", "reboot"], check=True)
-        exit()  # Exit as the system is rebooting
     
     # After any program finishes, redraw the menu
     menu_instance.draw()


### PR DESCRIPTION
## Summary
- add Shutdown and Reboot options to the Settings menu
- remove Shutdown and Reboot from the main menu
- handle shutdown/reboot within the settings handler
- update documentation to reflect new menu location

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684949c11050832fa62ecfd5ed7855fb