### PR TITLE
Add browser settings control

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,10 @@ The service definition will start the program on boot and restart it automatical
 ## NYT Top Stories
 
 The menu can fetch headlines from the New York Times API. Copy `nyt_config.py.example` to `nyt_config.py` and add your API key. The file is in `.gitignore` so your key stays local.
+
+## Web Interface
+
+A lightweight web server can be started from the **Utilities** menu. It exposes
+a simple browser based interface for viewing and updating settings. From the
+`/settings` page you can change the display brightness, select a font and adjust
+the text size. Wi-Fi can also be toggled on or off directly from the browser.


### PR DESCRIPTION
## Summary
- extend simple web server to change Mini OS settings
- allow toggling Wi-Fi from the browser
- document new web interface

## Testing
- `python3 -m py_compile utilities/web_server.py`
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68495378d848832f9dc7ba123b786991