### PR TITLE
Add support for displaying axe web game

### DIFF
--- a/games/__init__.py
+++ b/games/__init__.py
@@ -1,2 +1,2 @@
-from . import snake, tetris, rps, space_invaders
-__all__ = ["snake", "tetris", "rps", "space_invaders"]
+from . import snake, tetris, rps, space_invaders, axe
+__all__ = ["snake", "tetris", "rps", "space_invaders", "axe"]

--- a/games/axe.py
+++ b/games/axe.py
@@ -1,0 +1,85 @@
+import asyncio
+import threading
+from io import BytesIO
+from PIL import Image
+import pyppeteer
+
+SCREEN_W = 128
+SCREEN_H = 128
+URL = "https://paulthomason.github.io/axe/"
+
+thread_safe_display = None
+fonts = None
+exit_cb = None
+
+browser = None
+page = None
+loop = None
+running = False
+update_task = None
+
+
+def init(display_func, fonts_tuple, quit_callback):
+    global thread_safe_display, fonts, exit_cb
+    thread_safe_display = display_func
+    fonts = fonts_tuple
+    exit_cb = quit_callback
+
+
+def start():
+    global loop, running
+    running = True
+    loop = asyncio.new_event_loop()
+    threading.Thread(target=loop.run_forever, daemon=True).start()
+    asyncio.run_coroutine_threadsafe(_launch(), loop)
+
+
+def _ensure_task(coro):
+    if loop:
+        return asyncio.run_coroutine_threadsafe(coro, loop)
+
+
+async def _launch():
+    global browser, page, update_task
+    browser = await pyppeteer.launch(headless=True, args=["--no-sandbox"])
+    page = await browser.newPage()
+    await page.setViewport({"width": 800, "height": 600})
+    await page.goto(URL)
+    update_task = asyncio.create_task(_update_loop())
+
+
+async def _update_loop():
+    while running:
+        await _draw_page()
+        await asyncio.sleep(0.1)
+
+
+async def _draw_page():
+    if not page:
+        return
+    data = await page.screenshot(fullPage=False)
+    img = Image.open(BytesIO(data)).resize((SCREEN_W, SCREEN_H))
+    thread_safe_display(img)
+
+
+def handle_input(pin):
+    if pin == "KEY1":
+        _ensure_task(page.keyboard.press(" "))
+    elif pin == "KEY2":
+        stop()
+
+
+def stop():
+    global running
+    running = False
+    _ensure_task(_shutdown())
+
+
+async def _shutdown():
+    global browser
+    if update_task:
+        update_task.cancel()
+    if browser:
+        await browser.close()
+    exit_cb()
+

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ import re
 import webbrowser
 import shutil
 import socket
-from games import snake, tetris, rps, space_invaders
+from games import snake, tetris, rps, space_invaders, axe
 
 # Luma.lcd imports and setup
 from luma.core.interface.serial import spi
@@ -545,6 +545,9 @@ def button_event_handler(channel):
         elif menu_instance.current_screen == "space_invaders":
             if pin_name in BUTTON_PINS:
                 handle_space_invaders_input(pin_name)
+        elif menu_instance.current_screen == "axe":
+            if pin_name in BUTTON_PINS:
+                handle_axe_input(pin_name)
         elif menu_instance.current_screen == "notes":
             if pin_name in BUTTON_PINS:
                 handle_notes_input(pin_name)
@@ -1505,6 +1508,17 @@ def start_space_invaders():
 def handle_space_invaders_input(pin_name):
     space_invaders.handle_input(pin_name)
 
+
+def start_axe():
+    stop_scrolling()
+    axe.init(thread_safe_display, (font_small, font_medium, font_large), show_main_menu)
+    menu_instance.current_screen = "axe"
+    axe.start()
+
+
+def handle_axe_input(pin_name):
+    axe.handle_input(pin_name)
+
 # --- Notes Program ---
 
 notes_text = ""
@@ -1873,6 +1887,7 @@ def show_games_menu():
         "Tetris",
         "Rock Paper Scissors",
         "Space Invaders",
+        "Axe",
         "Back",
     ]
     menu_instance.selected_item = 0
@@ -1899,6 +1914,9 @@ def handle_games_selection(selection):
         return
     elif selection == "Space Invaders":
         start_space_invaders()
+        return
+    elif selection == "Axe":
+        start_axe()
         return
     elif selection == "Back":
         show_main_menu()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ luma.lcd
 RPi.GPIO
 requests
 Flask
+pyppeteer


### PR DESCRIPTION
## Summary
- rewrite Axe mini game to load the online version
- fetch the page with pyppeteer, scale screenshots to 128x128
- send Button 1 presses as spacebar events
- add `pyppeteer` dependency

## Testing
- `python3 -m py_compile main.py games/axe.py`


------
https://chatgpt.com/codex/tasks/task_e_684955e2a708832fb120acc7fb77f463