### PR TITLE
Add Trivia game

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains a simple menu-based interface for a Raspberry Pi with a
 
 The interface now includes a Settings screen. A **Display** submenu lets you change the LCD backlight brightness, choose a different font and adjust the text size. Additional menu options briefly display the current date and time, a system monitor showing CPU temperature, load, frequency, memory and disk usage, and a network info screen with the current IP address and Wi-Fi SSID. Shutdown and Reboot options are available at the bottom of the Settings screen for safely powering off or restarting the Pi. An "Update and Restart" option pulls the latest code and restarts the service so the update takes effect.
 
-Two small games are included: a reaction-based **Button Game** and a memory challenge called **Launch Codes**. They can be started from the **Games** submenu and make use of the three buttons and joystick directions for input.
+Several games are included: a reaction-based **Button Game**, the memory challenge **Launch Codes**, classics like **Snake** and **Tetris**, **Rock Paper Scissors**, **Space Invaders**, and a **Trivia** quiz. Start them from the **Games** submenu using the buttons and joystick for input.
 
 An **Image Gallery** viewer is also included. Create an `images/` directory (the program will create it if missing) and place your 128x128 PNG or JPEG files there. When started from the menu you can flip through the pictures using the joystick left and right, and press the joystick in to return to the main menu.
 

--- a/games/__init__.py
+++ b/games/__init__.py
@@ -1,2 +1,2 @@
-from . import snake, tetris, rps, space_invaders
-__all__ = ["snake", "tetris", "rps", "space_invaders"]
+from . import snake, tetris, rps, space_invaders, trivia
+__all__ = ["snake", "tetris", "rps", "space_invaders", "trivia"]

--- a/games/trivia.py
+++ b/games/trivia.py
@@ -1,0 +1,124 @@
+import time
+from PIL import Image, ImageDraw
+
+thread_safe_display = None
+fonts = None
+exit_cb = None
+
+current_topic = None
+question_index = 0
+score = 0
+state = "topic"
+
+QUESTION_BANK = {
+    "Hawaii": [
+        {"q": "Capital of Hawaii?", "choices": ["Honolulu", "Hilo", "Kona"], "answer": 0},
+        {"q": "How many main islands?", "choices": ["5", "8", "12"], "answer": 1},
+        {"q": "Traditional dance?", "choices": ["Tango", "Hula", "Salsa"], "answer": 1},
+        {"q": "Volcanoes NP island?", "choices": ["Maui", "Oahu", "Hawaii"], "answer": 2},
+        {"q": "State fish?", "choices": ["Mahi Mahi", "Humuhumunukunukuapuaa", "Ahi"], "answer": 1},
+        {"q": "Highest peak?", "choices": ["Mauna Kea", "Haleakala", "Mauna Loa"], "answer": 0},
+        {"q": "Ocean around Hawaii?", "choices": ["Indian", "Pacific", "Atlantic"], "answer": 1},
+        {"q": "Famous Oahu beach?", "choices": ["Waikiki", "Bondi", "Venice"], "answer": 0},
+        {"q": "Statehood year?", "choices": ["1959", "1915", "1972"], "answer": 0},
+        {"q": "Word for hello?", "choices": ["Aloha", "Mahalo", "Hola"], "answer": 0},
+        {"q": "Time zone?", "choices": ["Pacific", "Hawaiian", "Central"], "answer": 1},
+        {"q": "USS Arizona Memorial?", "choices": ["Pearl Harbor", "Lahaina", "Hilo"], "answer": 0},
+        {"q": "Biggest industry?", "choices": ["Agriculture", "Tourism", "Mining"], "answer": 1},
+        {"q": "Garden Isle?", "choices": ["Kauai", "Molokai", "Lanai"], "answer": 0},
+        {"q": "Welcome garland?", "choices": ["Lei", "Tiara", "Wreath"], "answer": 0},
+    ],
+    "Veterinary Internal Medicine": [
+        {"q": "Dog heartworm?", "choices": ["Dirofilaria immitis", "Ancylostoma caninum", "Dipylidium"], "answer": 0},
+        {"q": "Cushing's excess of?", "choices": ["Thyroxine", "Cortisol", "Insulin"], "answer": 1},
+        {"q": "Cat hyperthyroid cause?", "choices": ["Renal failure", "Adenomatous hyperplasia", "Iodine deficiency"], "answer": 1},
+        {"q": "Insulin-secreting tumor?", "choices": ["Lymphoma", "Insulinoma", "Hemangioma"], "answer": 1},
+        {"q": "Addison's is lack of?", "choices": ["Adrenal hormones", "Thyroxine", "Insulin"], "answer": 0},
+        {"q": "FIP stands for?", "choices": ["Feline infectious peritonitis", "Feline intestinal parasites", "Feline immunologic problem"], "answer": 0},
+        {"q": "Best urine sample?", "choices": ["Voided", "Cystocentesis", "Floor swab"], "answer": 1},
+        {"q": "Shock fluid choice?", "choices": ["5% dextrose", "Isotonic crystalloids", "Hypertonic saline"], "answer": 1},
+        {"q": "Specific liver enzyme?", "choices": ["ALT", "CK", "Lipase"], "answer": 0},
+        {"q": "Image heart chambers?", "choices": ["CT", "Radiography", "Echocardiography"], "answer": 2},
+        {"q": "FeLV means?", "choices": ["Feline leukemia virus", "Feline liver virus", "Feline laryngeal virus"], "answer": 0},
+        {"q": "GDV abbreviation?", "choices": ["General dermatitis", "Gastric dilatation-volvulus", "Glandular dysplasia"], "answer": 1},
+        {"q": "Diabetes insipidus sign?", "choices": ["Polyuria/polydipsia", "Alopecia", "Hematuria"], "answer": 0},
+        {"q": "Pancreatitis test?", "choices": ["Spec cPL", "Creatinine", "ALT"], "answer": 0},
+        {"q": "Furosemide class?", "choices": ["Diuretic", "Analgesic", "Steroid"], "answer": 0},
+    ],
+}
+
+
+def init(display_func, fonts_tuple, quit_callback):
+    global thread_safe_display, fonts, exit_cb
+    thread_safe_display = display_func
+    fonts = fonts_tuple
+    exit_cb = quit_callback
+
+
+def start():
+    global state
+    state = "topic"
+    draw_topic_select()
+
+
+def handle_input(pin):
+    global state, current_topic, question_index, score
+    if state == "topic":
+        if pin == "KEY1":
+            current_topic = "Hawaii"
+            question_index = 0
+            score = 0
+            state = "quiz"
+            draw_question()
+        elif pin == "KEY2":
+            current_topic = "Veterinary Internal Medicine"
+            question_index = 0
+            score = 0
+            state = "quiz"
+            draw_question()
+        elif pin in ("JOY_PRESS", "KEY3"):
+            exit_cb()
+    elif state == "quiz":
+        if pin in ("KEY1", "KEY2", "KEY3"):
+            choice = {"KEY1": 0, "KEY2": 1, "KEY3": 2}[pin]
+            q = QUESTION_BANK[current_topic][question_index]
+            if choice == q["answer"]:
+                score += 1
+            question_index += 1
+            if question_index >= len(QUESTION_BANK[current_topic]):
+                draw_score()
+                time.sleep(2)
+                exit_cb()
+            else:
+                draw_question()
+        elif pin == "JOY_PRESS":
+            exit_cb()
+
+
+def draw_topic_select():
+    img = Image.new("RGB", (128, 128), "black")
+    d = ImageDraw.Draw(img)
+    d.text((10, 5), "Select Topic", font=fonts[1], fill=(255, 255, 255))
+    d.text((10, 40), "1=Hawaii", font=fonts[0], fill=(0, 255, 0))
+    d.text((10, 55), "2=Vet Med", font=fonts[0], fill=(0, 255, 0))
+    d.text((10, 90), "Press Joy to exit", font=fonts[0], fill=(255, 0, 0))
+    thread_safe_display(img)
+
+
+def draw_question():
+    img = Image.new("RGB", (128, 128), "black")
+    d = ImageDraw.Draw(img)
+    q = QUESTION_BANK[current_topic][question_index]
+    d.text((5, 5), f"Q{question_index + 1}: {q['q']}", font=fonts[0], fill=(255, 255, 255))
+    d.text((5, 40), f"1 {q['choices'][0]}", font=fonts[0], fill=(0, 255, 0))
+    d.text((5, 55), f"2 {q['choices'][1]}", font=fonts[0], fill=(0, 255, 0))
+    d.text((5, 70), f"3 {q['choices'][2]}", font=fonts[0], fill=(0, 255, 0))
+    thread_safe_display(img)
+
+
+def draw_score():
+    img = Image.new("RGB", (128, 128), "black")
+    d = ImageDraw.Draw(img)
+    total = len(QUESTION_BANK[current_topic])
+    d.text((20, 50), f"Score {score}/{total}", font=fonts[1], fill=(255, 255, 0))
+    thread_safe_display(img)

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ import re
 import webbrowser
 import shutil
 import socket
-from games import snake, tetris, rps, space_invaders
+from games import snake, tetris, rps, space_invaders, trivia
 
 # Luma.lcd imports and setup
 from luma.core.interface.serial import spi
@@ -545,6 +545,9 @@ def button_event_handler(channel):
         elif menu_instance.current_screen == "space_invaders":
             if pin_name in BUTTON_PINS:
                 handle_space_invaders_input(pin_name)
+        elif menu_instance.current_screen == "trivia":
+            if pin_name in BUTTON_PINS:
+                handle_trivia_input(pin_name)
         elif menu_instance.current_screen == "notes":
             if pin_name in BUTTON_PINS:
                 handle_notes_input(pin_name)
@@ -1505,6 +1508,17 @@ def start_space_invaders():
 def handle_space_invaders_input(pin_name):
     space_invaders.handle_input(pin_name)
 
+
+def start_trivia():
+    stop_scrolling()
+    trivia.init(thread_safe_display, (font_small, font_medium, font_large), show_main_menu)
+    menu_instance.current_screen = "trivia"
+    trivia.start()
+
+
+def handle_trivia_input(pin_name):
+    trivia.handle_input(pin_name)
+
 # --- Notes Program ---
 
 notes_text = ""
@@ -1873,6 +1887,7 @@ def show_games_menu():
         "Tetris",
         "Rock Paper Scissors",
         "Space Invaders",
+        "Trivia",
         "Back",
     ]
     menu_instance.selected_item = 0
@@ -1899,6 +1914,9 @@ def handle_games_selection(selection):
         return
     elif selection == "Space Invaders":
         start_space_invaders()
+        return
+    elif selection == "Trivia":
+        start_trivia()
         return
     elif selection == "Back":
         show_main_menu()


### PR DESCRIPTION
## Summary
- introduce a new `Trivia` game with Hawaii and Veterinary Internal Medicine topics
- wire the Trivia game into the games package and menu system
- list all available games in the README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684956afedac832f8be4749dcb66c5b9