### PR TITLE
Add Bluetooth pairing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,11 @@ A lightweight web server can be started from the **Utilities** menu. It exposes
 a simple browser based interface for viewing and updating settings. From the
 `/settings` page you can change the display brightness, select a font and adjust
 the text size. Wi-Fi can also be toggled on or off directly from the browser.
+
+## Bluetooth
+
+From **Settings** choose **Bluetooth** to scan for nearby devices. Select your
+iPhone or other device with the joystick. Press **KEY1** to attempt a direct
+connection or **KEY2** to pair and connect (useful for phones that require
+confirming a passkey such as the iPhone 15 Pro Max). Ensure the phone is in
+Bluetooth pairing mode when attempting to connect.

--- a/main.py
+++ b/main.py
@@ -456,6 +456,12 @@ def button_event_handler(channel):
                     show_settings_menu()
                 else:
                     connect_bluetooth_device(selection)
+            elif pin_name == "KEY2":
+                selection = menu_instance.get_selected_item()
+                if selection == "Back" or selection == "No Devices Found":
+                    show_settings_menu()
+                else:
+                    connect_bluetooth_device_with_pin(selection)
         elif menu_instance.current_screen == "games":
             if pin_name == "JOY_UP":
                 menu_instance.navigate("up")


### PR DESCRIPTION
## Summary
- allow pairing via KEY2 in Bluetooth device list
- document Bluetooth usage in README

## Testing
- `python3 -m py_compile main.py utilities/*.py games/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684967b9d5b8832f951d1a9d0b44acc7