### PR TITLE
Add raspi-config wrapper

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ luma.lcd
 RPi.GPIO
 requests
 Flask
+pexpect>=4.9.0


### PR DESCRIPTION
## Summary
- add pexpect to handle interactive shells
- add new `raspi-config` option to Settings menu
- implement basic wrapper to run `sudo raspi-config` in tiny display

## Testing
- `python3 -m py_compile main.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68499351f65c832f8295932cfed3ef77