### PR TITLE
Add persistent web shell with password handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ a simple browser based interface for viewing and updating settings. From the
 `/settings` page you can change the display brightness, select a font and adjust
 the text size. Wi-Fi can also be toggled on or off directly from the browser.
 
+### Interactive Shell
+
+Opening `/shell` in a browser now provides a live Bash prompt. Commands are
+executed in a persistent shell so each one can build on the previous. If a
+command asks for a password (for example when using `sudo`), a password field
+will appear so you can respond directly in the browser.
+
+**Security Warning:** anyone who can access this page can run arbitrary commands
+on your Pi. Only enable the web server on trusted networks and consider adding
+additional authentication if it is exposed beyond localhost.
+
 ## Bluetooth
 
 From **Settings** choose **Bluetooth** to scan for nearby devices. Select your


### PR DESCRIPTION
## Summary
- support an interactive web shell using `pexpect`
- allow entering sudo passwords when prompted
- warn about the security implications of enabling the web shell in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pip install Flask`
- `pip install pexpect==4.9.0`
- `python3 utilities/web_server.py >server.log 2>&1 &`
- `curl -s http://127.0.0.1:8000/`
- `curl -s -X POST -d 'cmd=echo hello' http://127.0.0.1:8000/shell`
- `curl -s -X POST -d "cmd=python3 -c 'print(\"before\"); input(\"sudo password:\"); print(\"after\")'" http://127.0.0.1:8000/shell`
- `curl -s -X POST -d 'password=secret' http://127.0.0.1:8000/shell`
- `kill <pid>`

------
https://chatgpt.com/codex/tasks/task_e_68499e5963a8832fabc6306826025501