### PR TITLE
Add timeout handling in web shell

### DIFF
--- a/utilities/web_server.py
+++ b/utilities/web_server.py
@@ -171,6 +171,8 @@ def shell():
                 ).decode()
             except subprocess.CalledProcessError as e:
                 output = e.output.decode() if e.output else str(e)
+            except subprocess.TimeoutExpired:
+                output = "Command timed out"
             except Exception as e:
                 output = str(e)
             SHELL_HISTORY.append((cmd, output))


### PR DESCRIPTION
## Summary
- handle `subprocess.TimeoutExpired` in `/shell` route

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68499e62bd8c832fa06fcc4c110f88c0