### PR TITLE
Add timeout handling in web shell

### DIFF
--- a/utilities/web_server.py
+++ b/utilities/web_server.py
@@ -169,6 +169,10 @@ def shell():
                 output = subprocess.check_output(
                     cmd, shell=True, stderr=subprocess.STDOUT, timeout=10
                 ).decode()
+            except subprocess.TimeoutExpired:
+                output = "Command timed out"
+                SHELL_HISTORY.append((cmd, output))
+                return output
             except subprocess.CalledProcessError as e:
                 output = e.output.decode() if e.output else str(e)
             except Exception as e:


### PR DESCRIPTION
## Summary
- handle `subprocess.TimeoutExpired` in `/shell` route and directly return message

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68499e62bd8c832fa06fcc4c110f88c0