### PR TITLE
Improve shell timeout feedback

### DIFF
--- a/main.py
+++ b/main.py
@@ -2168,6 +2168,9 @@ def run_sudo_command(cmd, password):
         )
         success = result.returncode == 0
         output = result.stdout
+    except subprocess.TimeoutExpired:
+        success = False
+        output = "Command timed out"
     except Exception as e:
         success = False
         output = str(e)
@@ -2217,7 +2220,11 @@ def run_shell_command(cmd):
         start_sudo_password(cmd)
         return
     try:
-        output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT, timeout=10).decode()
+        output = subprocess.check_output(
+            cmd, shell=True, stderr=subprocess.STDOUT, timeout=10
+        ).decode()
+    except subprocess.TimeoutExpired:
+        output = "Command timed out"
     except subprocess.CalledProcessError as e:
         output = e.output.decode() if e.output else str(e)
     except Exception as e:


### PR DESCRIPTION
## Summary
- handle `pexpect.TIMEOUT` in the web shell
- catch `subprocess.TimeoutExpired` in shell helper functions

## Testing
- `python3 -m py_compile utilities/web_server.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_6849b98f91c4832f987bbd4abf2bf148