### PR TITLE
Redesign axe game layout

### DIFF
--- a/games/axe.py
+++ b/games/axe.py
@@ -6,14 +6,17 @@ from PIL import Image, ImageDraw
 SCREEN_W = 128
 SCREEN_H = 128
 
-# Target radii based on canvas size
+# Target radii based on canvas size. The game now centers a much larger target
+# so the radii are increased compared to the original values.
 BASE = min(SCREEN_W, SCREEN_H)
-TARGET_RADIUS_OUTERMOST = int(BASE * 0.225)
-TARGET_RADIUS_OUTER = int(BASE * 0.167)
-TARGET_RADIUS_MIDDLE = int(BASE * 0.108)
-TARGET_RADIUS_INNER = int(BASE * 0.05)
-AIM_SLIDER_LENGTH = int(TARGET_RADIUS_OUTERMOST * 2 * 1.3)
-POWER_SLIDER_LENGTH = int(TARGET_RADIUS_OUTERMOST * 2)
+TARGET_RADIUS_OUTERMOST = int(BASE * 0.4)
+TARGET_RADIUS_OUTER = int(BASE * 0.3)
+TARGET_RADIUS_MIDDLE = int(BASE * 0.2)
+TARGET_RADIUS_INNER = int(BASE * 0.1)
+
+# Slider lengths are derived from the new target size
+AIM_SLIDER_LENGTH = TARGET_RADIUS_OUTERMOST * 2
+POWER_SLIDER_LENGTH = TARGET_RADIUS_OUTERMOST * 2
 
 STATE_AIM_H = 0
 STATE_AIM_V = 1
@@ -131,7 +134,8 @@ def evaluate_throw():
     v_off = (v_pos - 0.5) * AIM_SLIDER_LENGTH
     power_effect = (0.65 - p_pos) * (TARGET_RADIUS_OUTERMOST * 2)
     target_x = SCREEN_W // 2 + h_off
-    target_y = SCREEN_H // 3 + v_off + power_effect
+    # Target is now centered on the screen
+    target_y = SCREEN_H // 2 + v_off + power_effect
     # random offset increases with power difference
     acc_mod = 1 - abs(p_pos - 0.65) / 0.65
     acc_mod = max(0, acc_mod)
@@ -139,7 +143,7 @@ def evaluate_throw():
     target_x += random.uniform(-max_rand, max_rand)
     target_y += random.uniform(-max_rand, max_rand)
     dx = target_x - SCREEN_W // 2
-    dy = target_y - SCREEN_H // 3
+    dy = target_y - SCREEN_H // 2
     dist = (dx * dx + dy * dy) ** 0.5
     if dist <= TARGET_RADIUS_INNER:
         return "Bullseye! +10"
@@ -156,8 +160,9 @@ def draw():
     img = Image.new("RGB", (SCREEN_W, SCREEN_H), "white")
     d = ImageDraw.Draw(img)
     tx = SCREEN_W // 2
-    ty = SCREEN_H // 3
-    # target
+    ty = SCREEN_H // 2
+
+    # draw target centered on the screen
     d.ellipse([tx - TARGET_RADIUS_OUTERMOST, ty - TARGET_RADIUS_OUTERMOST,
                tx + TARGET_RADIUS_OUTERMOST, ty + TARGET_RADIUS_OUTERMOST], fill="#d8b373")
     d.ellipse([tx - TARGET_RADIUS_OUTER, ty - TARGET_RADIUS_OUTER,
@@ -167,36 +172,48 @@ def draw():
     d.ellipse([tx - TARGET_RADIUS_INNER, ty - TARGET_RADIUS_INNER,
                tx + TARGET_RADIUS_INNER, ty + TARGET_RADIUS_INNER], fill="#e53636")
 
+    # slider/indicator positions
+    h_y = ty + TARGET_RADIUS_OUTERMOST + 10
+    v_x = tx - TARGET_RADIUS_OUTERMOST - 4
+    pow_w = 6
+    pow_x0 = v_x - pow_w - 2
+    pow_x1 = pow_x0 + pow_w
+    pow_top = ty - TARGET_RADIUS_OUTERMOST
+    pow_bottom = ty + TARGET_RADIUS_OUTERMOST
+
     if state == STATE_AIM_H:
-        x = tx - AIM_SLIDER_LENGTH//2 + int(h_pos*AIM_SLIDER_LENGTH)
-        d.line([x, ty - TARGET_RADIUS_OUTERMOST - 15, x, ty + TARGET_RADIUS_OUTERMOST + 15], fill="blue")
+        x = tx - AIM_SLIDER_LENGTH // 2 + int(h_pos * AIM_SLIDER_LENGTH)
+        d.line([tx - AIM_SLIDER_LENGTH // 2, h_y, tx + AIM_SLIDER_LENGTH // 2, h_y], fill="black")
+        d.rectangle([x-2, h_y-4, x+2, h_y+4], fill="blue")
     elif state == STATE_AIM_V:
-        y = ty - AIM_SLIDER_LENGTH//2 + int(v_pos*AIM_SLIDER_LENGTH)
-        d.line([tx - TARGET_RADIUS_OUTERMOST - 15, y, tx + TARGET_RADIUS_OUTERMOST + 15, y], fill="blue")
-        x = tx - AIM_SLIDER_LENGTH//2 + int(h_pos*AIM_SLIDER_LENGTH)
-        d.line([x, ty - TARGET_RADIUS_OUTERMOST - 15, x, ty + TARGET_RADIUS_OUTERMOST + 15], fill="gray")
+        y = ty - AIM_SLIDER_LENGTH // 2 + int(v_pos * AIM_SLIDER_LENGTH)
+        d.line([v_x, ty - AIM_SLIDER_LENGTH // 2, v_x, ty + AIM_SLIDER_LENGTH // 2], fill="black")
+        d.rectangle([v_x-4, y-2, v_x+4, y+2], fill="blue")
+        # show locked horizontal slider
+        xh = tx - AIM_SLIDER_LENGTH // 2 + int(h_pos * AIM_SLIDER_LENGTH)
+        d.line([tx - AIM_SLIDER_LENGTH // 2, h_y, tx + AIM_SLIDER_LENGTH // 2, h_y], fill="gray")
+        d.rectangle([xh-2, h_y-4, xh+2, h_y+4], fill="gray")
     elif state == STATE_AIM_P:
-        y = SCREEN_H - 20
-        x0 = tx - POWER_SLIDER_LENGTH//2
-        x1 = tx + POWER_SLIDER_LENGTH//2
-        d.line([x0, y, x1, y], fill="black")
-        x = x0 + int(p_pos*POWER_SLIDER_LENGTH)
-        d.rectangle([x-2, y-8, x+2, y+8], fill="red")
-        # draw previous sliders locked
-        xh = tx - AIM_SLIDER_LENGTH//2 + int(h_pos*AIM_SLIDER_LENGTH)
-        d.line([xh, ty - TARGET_RADIUS_OUTERMOST - 15, xh, ty + TARGET_RADIUS_OUTERMOST + 15], fill="gray")
-        yv = ty - AIM_SLIDER_LENGTH//2 + int(v_pos*AIM_SLIDER_LENGTH)
-        d.line([tx - TARGET_RADIUS_OUTERMOST - 15, yv, tx + TARGET_RADIUS_OUTERMOST + 15, yv], fill="gray")
+        # power meter
+        d.rectangle([pow_x0, pow_top, pow_x1, pow_bottom], outline="black")
+        fill_height = int(p_pos * (pow_bottom - pow_top))
+        d.rectangle([pow_x0+1, pow_bottom-fill_height, pow_x1-1, pow_bottom-1], fill="red")
+        # show locked aim sliders
+        xh = tx - AIM_SLIDER_LENGTH // 2 + int(h_pos * AIM_SLIDER_LENGTH)
+        yv = ty - AIM_SLIDER_LENGTH // 2 + int(v_pos * AIM_SLIDER_LENGTH)
+        d.line([tx - AIM_SLIDER_LENGTH // 2, h_y, tx + AIM_SLIDER_LENGTH // 2, h_y], fill="gray")
+        d.rectangle([xh-2, h_y-4, xh+2, h_y+4], fill="gray")
+        d.line([v_x, ty - AIM_SLIDER_LENGTH // 2, v_x, ty + AIM_SLIDER_LENGTH // 2], fill="gray")
+        d.rectangle([v_x-4, yv-2, v_x+4, yv+2], fill="gray")
     elif state == STATE_RESULT:
         d.text((10, SCREEN_H - 30), result_text, font=fonts[0], fill="black")
-        # show locked sliders
-        xh = tx - AIM_SLIDER_LENGTH//2 + int(h_pos*AIM_SLIDER_LENGTH)
-        d.line([xh, ty - TARGET_RADIUS_OUTERMOST - 15, xh, ty + TARGET_RADIUS_OUTERMOST + 15], fill="gray")
-        yv = ty - AIM_SLIDER_LENGTH//2 + int(v_pos*AIM_SLIDER_LENGTH)
-        d.line([tx - TARGET_RADIUS_OUTERMOST - 15, yv, tx + TARGET_RADIUS_OUTERMOST + 15, yv], fill="gray")
-        # power slider
-        y = SCREEN_H - 20
-        x0 = tx - POWER_SLIDER_LENGTH//2
-        x = x0 + int(p_pos*POWER_SLIDER_LENGTH)
-        d.rectangle([x-2, y-8, x+2, y+8], fill="gray")
+        xh = tx - AIM_SLIDER_LENGTH // 2 + int(h_pos * AIM_SLIDER_LENGTH)
+        yv = ty - AIM_SLIDER_LENGTH // 2 + int(v_pos * AIM_SLIDER_LENGTH)
+        d.line([tx - AIM_SLIDER_LENGTH // 2, h_y, tx + AIM_SLIDER_LENGTH // 2, h_y], fill="gray")
+        d.rectangle([xh-2, h_y-4, xh+2, h_y+4], fill="gray")
+        d.line([v_x, ty - AIM_SLIDER_LENGTH // 2, v_x, ty + AIM_SLIDER_LENGTH // 2], fill="gray")
+        d.rectangle([v_x-4, yv-2, v_x+4, yv+2], fill="gray")
+        d.rectangle([pow_x0, pow_top, pow_x1, pow_bottom], outline="black")
+        fill_height = int(p_pos * (pow_bottom - pow_top))
+        d.rectangle([pow_x0+1, pow_bottom-fill_height, pow_x1-1, pow_bottom-1], fill="gray")
     thread_safe_display(img)


### PR DESCRIPTION
## Summary
- scale up the axe throwing target and center it on screen
- reposition aim sliders and add vertical power meter

## Testing
- `python3 -m py_compile games/axe.py`
- `python3 -m py_compile games/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6849bd285090832f9bdbaa8f7c27d4d2