### PR TITLE
Persist color scheme across restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains a simple menu-based interface for a Raspberry Pi with a
 The interface now includes a Settings screen. A **Display** submenu lets you change the LCD backlight brightness, choose a different font, select a color scheme and adjust the text size. Additional menu options briefly display the current date and time, a system monitor showing CPU temperature, load, frequency, memory and disk usage, and a network info screen with the current IP address and Wi-Fi SSID. Shutdown and Reboot options are available at the bottom of the Settings screen for safely powering off or restarting the Pi. An "Update and Restart" option pulls the latest code and restarts the service so the update takes effect.
 
 The color scheme selector now includes Mac&nbsp;Terminal palettes like **Terminal Basic**, **Grass**, **Man Page**, **Novel**, **Ocean**, **Red Sands**, **Espresso**, **Homebrew** and **Pro** in addition to the default theme.
+Your last selected scheme is written to `settings.json` so it loads the same palette after a reboot.
 
 Several small games are included: the reaction-based **Button Game**, the memory challenge **Launch Codes**, classics like **Snake** and **Tetris**, a simple **Rock Paper Scissors**, **Space Invaders**, and a text based adventure called **Vet Adventure**. Recent additions like **Axe**, **Trivia**, **Hack In**, and **Pico WoW** round out the selection. They can be started from the **Games** submenu and make use of the three buttons and joystick directions for input.
 

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ import re
 import webbrowser
 import shutil
 import socket
+import json
 import pexpect
 from games import (
     snake,
@@ -244,6 +245,7 @@ def apply_color_scheme(name):
     if name in COLOR_SCHEMES:
         current_color_scheme = COLOR_SCHEMES[name]
         current_color_scheme_name = name
+        save_settings()
         if menu_instance:
             menu_instance.draw()
 
@@ -294,6 +296,32 @@ gallery_index = 0
 # --- Notes Directory ---
 NOTES_DIR = os.path.join(os.path.dirname(__file__), "notes")
 os.makedirs(NOTES_DIR, exist_ok=True)
+
+# Configuration file for persisting settings like color scheme
+SETTINGS_FILE = os.path.join(os.path.dirname(__file__), "settings.json")
+
+
+def save_settings():
+    """Persist current settings to disk."""
+    try:
+        with open(SETTINGS_FILE, "w") as f:
+            json.dump({"color_scheme": current_color_scheme_name}, f)
+    except Exception as e:
+        print(f"Failed to save settings: {e}")
+
+
+def load_settings():
+    """Load settings from disk if available."""
+    if not os.path.exists(SETTINGS_FILE):
+        return
+    try:
+        with open(SETTINGS_FILE) as f:
+            data = json.load(f)
+        scheme = data.get("color_scheme")
+        if scheme in COLOR_SCHEMES:
+            apply_color_scheme(scheme)
+    except Exception as e:
+        print(f"Failed to load settings: {e}")
 
 # --- IRC Chat ---
 IRC_SERVER = "192.168.0.81"
@@ -2935,6 +2963,7 @@ def handle_menu_selection(selection):
 
 # --- Main Execution ---
 if __name__ == "__main__":
+    load_settings()
     menu_instance = Menu([])
     connect_irc()
     show_main_menu()


### PR DESCRIPTION
## Summary
- remember the user's color scheme selection in `settings.json`
- reload the saved color scheme when Mini OS starts
- document the new behavior in the README

## Testing
- `python3 -m py_compile main.py utilities/*.py games/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684a915c8284832f84fa8b4b208fa5b4