### PR TITLE
Fix disconnect message quoting

### DIFF
--- a/utilities/web_server.py
+++ b/utilities/web_server.py
@@ -227,7 +227,7 @@ def shell():
         socket.onopen = () => term.focus();
         term.onData(d => socket.send(d));
         socket.onmessage = e => term.write(e.data);
-        socket.onclose = () => term.write('\r\n[Disconnected]');
+        socket.onclose = () => term.write("\r\n[Disconnected]");
     </script>
     </body>
     </html>


### PR DESCRIPTION
## Summary
- use double quotes for the disconnect message in the inline shell script

## Testing
- `python3 -m py_compile utilities/web_server.py`

------
https://chatgpt.com/codex/tasks/task_e_684a999f93bc832fbdf38d642e24daa3