### PR TITLE
Fix web shell disconnect message escaping

### DIFF
--- a/utilities/web_server.py
+++ b/utilities/web_server.py
@@ -227,7 +227,9 @@ def shell():
         socket.onopen = () => term.focus();
         term.onData(d => socket.send(d));
         socket.onmessage = e => term.write(e.data);
-        socket.onclose = () => term.write('\r\n[Disconnected]');
+        // Send a CRLF sequence when the WebSocket closes
+        // Use double escaping so the JS string contains "\\r\\n"
+        socket.onclose = () => term.write("\\r\\n[Disconnected]");
     </script>
     </body>
     </html>


### PR DESCRIPTION
## Summary
- escape CRLF in inline shell JavaScript

## Testing
- `python3 -m py_compile utilities/web_server.py`

------
https://chatgpt.com/codex/tasks/task_e_684a999f93bc832fbdf38d642e24daa3