### PR TITLE
Add GTA 1997 style mini game

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The interface now includes a Settings screen. A **Display** submenu lets you cha
 The color scheme selector now includes Mac&nbsp;Terminal palettes like **Terminal Basic**, **Grass**, **Man Page**, **Novel**, **Ocean**, **Red Sands**, **Espresso**, **Homebrew** and **Pro** in addition to the default theme.
 Your last selected scheme is written to `settings.json` so it loads the same palette after a reboot.
 
-Several small games are included: the reaction-based **Button Game**, the memory challenge **Launch Codes**, classics like **Snake** and **Tetris**, a simple **Rock Paper Scissors**, **Space Invaders**, and a text based adventure called **Vet Adventure**. Recent additions like **Axe**, **Trivia**, **Hack In**, and **Pico WoW** round out the selection. They can be started from the **Games** submenu and make use of the three buttons and joystick directions for input.
+Several small games are included: the reaction-based **Button Game**, the memory challenge **Launch Codes**, classics like **Snake** and **Tetris**, a simple **Rock Paper Scissors**, **Space Invaders**, and a text based adventure called **Vet Adventure**. Recent additions like **Axe**, **Trivia**, **Hack In**, **Pico WoW**, and a minimalist top-down driving game **GTA 1997** round out the selection. They can be started from the **Games** submenu and make use of the three buttons and joystick directions for input.
 
 An **Image Gallery** viewer is also included. Create an `images/` directory (the program will create it if missing) and place your 128x128 PNG or JPEG files there. When started from the menu you can flip through the pictures using the joystick left and right, and press the joystick in to return to the main menu.
 

--- a/games/__init__.py
+++ b/games/__init__.py
@@ -8,6 +8,7 @@ from . import (
     trivia,
     hack_in,
     pico_wow,
+    gta_1997,
 )
 __all__ = [
     "snake",
@@ -19,4 +20,5 @@ __all__ = [
     "trivia",
     "hack_in",
     "pico_wow",
+    "gta_1997",
 ]

--- a/main.py
+++ b/main.py
@@ -24,6 +24,7 @@ from games import (
     trivia,
     hack_in,
     pico_wow,
+    gta_1997,
 )
 
 # Luma.lcd imports and setup
@@ -783,6 +784,9 @@ def button_event_handler(channel):
         elif menu_instance.current_screen == "pico_wow":
             if pin_name in BUTTON_PINS:
                 handle_pico_wow_input(pin_name)
+        elif menu_instance.current_screen == "gta_1997":
+            if pin_name in BUTTON_PINS:
+                handle_gta_1997_input(pin_name)
         elif menu_instance.current_screen == "notes":
             if pin_name in BUTTON_PINS:
                 handle_notes_input(pin_name)
@@ -1965,6 +1969,18 @@ def start_hack_in():
 def handle_hack_in_input(pin_name):
     hack_in.handle_input(pin_name)
 
+# --- GTA 1997 Style Game ---
+
+def start_gta_1997():
+    stop_scrolling()
+    gta_1997.init(thread_safe_display, (font_small, font_medium, font_large), show_main_menu)
+    menu_instance.current_screen = "gta_1997"
+    gta_1997.start()
+
+
+def handle_gta_1997_input(pin_name):
+    gta_1997.handle_input(pin_name)
+
 # --- Notes Program ---
 
 notes_text = ""
@@ -2886,6 +2902,7 @@ def show_games_menu():
         "Trivia",
         "Hack In",
         "Pico WoW",
+        "GTA 1997",
         "Back",
     ]
     menu_instance.selected_item = 0
@@ -2927,6 +2944,9 @@ def handle_games_selection(selection):
         return
     elif selection == "Pico WoW":
         start_pico_wow()
+        return
+    elif selection == "GTA 1997":
+        start_gta_1997()
         return
     elif selection == "Back":
         show_main_menu()


### PR DESCRIPTION
## Summary
- add GTA 1997 style top-down driving game
- expose the new game from `games/__init__.py`
- integrate the game into `main.py` menus and handlers
- mention new game in README

## Testing
- `python3 -m py_compile games/gta_1997.py`
- `python3 -m py_compile main.py`
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684ae0eab610832fafc895e98f231077