### PR TITLE
Add veterinary-themed HTML mini games

### DIFF
--- a/main.py
+++ b/main.py
@@ -1799,6 +1799,30 @@ def start_web_server():
         )
         show_utilities_menu()
 
+def start_mini_games():
+    """Launch the web-based mini games."""
+    try:
+        ip_output = subprocess.check_output(["hostname", "-I"]).decode().strip()
+        ip_addr = ip_output.split()[0] if ip_output else "localhost"
+    except Exception:
+        ip_addr = "localhost"
+
+    try:
+        from utilities import web_server
+        threading.Thread(target=web_server.run, daemon=True).start()
+    except Exception:
+        pass
+
+    try:
+        webbrowser.open(f"http://{ip_addr}:8000/mini-games")
+    except Exception:
+        pass
+
+    menu_instance.display_message_screen(
+        "Mini Games", f"Open http://{ip_addr}:8000/mini-games", delay=4
+    )
+    show_games_menu()
+
 # --- Reaction Game ---
 
 def draw_game_screen(prompt, time_left=None):
@@ -3104,6 +3128,7 @@ def show_games_menu():
         "Axe",
         "Trivia",
         "Two Player Trivia",
+        "Mini Games",
         "Hack In",
         "Pico WoW",
         "GTA 1997",
@@ -3145,6 +3170,9 @@ def handle_games_selection(selection):
         return
     elif selection == "Two Player Trivia":
         start_two_player_trivia()
+        return
+    elif selection == "Mini Games":
+        start_mini_games()
         return
     elif selection == "Hack In":
         start_hack_in()

--- a/utilities/web_server.py
+++ b/utilities/web_server.py
@@ -7,7 +7,7 @@ import threading
 import importlib
 import subprocess
 import pexpect
-from flask import Flask, request, redirect
+from flask import Flask, request, redirect, send_from_directory
 from flask_sock import Sock
 
 app = Flask(__name__)
@@ -20,6 +20,8 @@ os.makedirs(NOTES_DIR, exist_ok=True)
 NYT_API_KEY = None
 CHAT_LOG = []
 
+WEB_GAMES_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "web_games")
+os.makedirs(WEB_GAMES_DIR, exist_ok=True)
 
 @sock.route("/shell/ws")
 def shell_ws(ws):
@@ -72,6 +74,7 @@ def index():
         "<li><a href='/chat'>Chat</a></li>"
         "<li><a href='/shell'>Shell</a></li>"
         "<li><a href='/top-stories'>Top Stories</a></li>"
+        "<li><a href='/mini-games'>Mini Games</a></li>"
         "</ul>"
     )
 
@@ -236,6 +239,17 @@ def shell():
     </html>
     """
 
+
+@app.route("/mini-games")
+def mini_games_index():
+    """Serve the mini games menu page."""
+    return send_from_directory(WEB_GAMES_DIR, "index.html")
+
+
+@app.route("/mini-games/<path:filename>")
+def mini_games_static(filename):
+    """Serve static files for mini games."""
+    return send_from_directory(WEB_GAMES_DIR, filename)
 
 @app.route("/top-stories")
 def top_stories():

--- a/web_games/feline_fever.html
+++ b/web_games/feline_fever.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Feline Fever Finder</title>
+  <style>
+    body { text-align: center; font-family: sans-serif; background: #fffaf8; }
+    canvas { border: 1px solid #ccc; display: block; margin: 10px auto; background: #ffeeee; }
+  </style>
+</head>
+<body>
+  <h1>Feline Fever Finder</h1>
+  <canvas id="game" width="400" height="400"></canvas>
+  <p id="status">Score: 0 | Time: 30</p>
+  <script>
+    const canvas = document.getElementById('game');
+    const ctx = canvas.getContext('2d');
+    let score = 0;
+    let time = 30;
+    const size = 40;
+    let cat = {x: Math.random()*(canvas.width-size), y: Math.random()*(canvas.height-size)};
+
+    function draw() {
+      ctx.clearRect(0,0,canvas.width,canvas.height);
+      ctx.fillStyle = 'orange';
+      ctx.fillRect(cat.x, cat.y, size, size);
+      ctx.fillStyle = 'black';
+      ctx.font = '16px sans-serif';
+      ctx.fillText('Score: '+score, 10, 20);
+      ctx.fillText('Time: '+time, canvas.width-80, 20);
+    }
+
+    function moveCat() {
+      cat.x = Math.random()*(canvas.width-size);
+      cat.y = Math.random()*(canvas.height-size);
+    }
+
+    canvas.addEventListener('click', e => {
+      const rect = canvas.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      if (x > cat.x && x < cat.x+size && y > cat.y && y < cat.y+size) {
+        score++;
+        moveCat();
+        draw();
+      }
+    });
+
+    function countdown() {
+      time--;
+      document.getElementById('status').textContent = 'Score: '+score+' | Time: '+time;
+      if (time <= 0) {
+        clearInterval(timer);
+        clearInterval(catTimer);
+        alert('Time\'s up! Your score: '+score);
+      }
+    }
+
+    draw();
+    const timer = setInterval(countdown, 1000);
+    const catTimer = setInterval(() => { moveCat(); draw(); }, 1000);
+  </script>
+  <p><a href="index.html">Back</a></p>
+</body>
+</html>

--- a/web_games/index.html
+++ b/web_games/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Mini Games</title>
+  <style>
+    body { font-family: sans-serif; text-align: center; background: #fafafa; }
+    h1 { margin-top: 30px; }
+    a.game-link { display: block; margin: 15px; font-size: 20px; }
+  </style>
+</head>
+<body>
+  <h1>Veterinary Mini Games</h1>
+  <a class="game-link" href="feline_fever.html">Feline Fever Finder</a>
+  <a class="game-link" href="kidney_catch.html">Canine Kidney Catch</a>
+  <a class="game-link" href="parasite_pop.html">Parasite Pop</a>
+  <p><a href="/">Back to main page</a></p>
+</body>
+</html>

--- a/web_games/kidney_catch.html
+++ b/web_games/kidney_catch.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Canine Kidney Catch</title>
+  <style>
+    body { text-align: center; font-family: sans-serif; background:#f0faff; }
+    canvas { border:1px solid #ccc; display:block; margin:10px auto; background:#e0f7ff; }
+  </style>
+</head>
+<body>
+  <h1>Canine Kidney Catch</h1>
+  <canvas id="game" width="400" height="400"></canvas>
+  <p id="status">Score: 0 | Time: 30</p>
+  <script>
+    const canvas = document.getElementById('game');
+    const ctx = canvas.getContext('2d');
+    const dog = {x: canvas.width/2-20, y: canvas.height-40, w:40, h:20};
+    const kidneys = [];
+    let score = 0;
+    let time = 30;
+    document.addEventListener('keydown', e => {
+      if(e.key==='ArrowLeft') dog.x = Math.max(0, dog.x-20);
+      if(e.key==='ArrowRight') dog.x = Math.min(canvas.width-dog.w, dog.x+20);
+    });
+    function spawnKidney(){
+      kidneys.push({x: Math.random()*(canvas.width-10), y:0});
+    }
+    function update(){
+      ctx.clearRect(0,0,canvas.width,canvas.height);
+      ctx.fillStyle='brown';
+      ctx.fillRect(dog.x,dog.y,dog.w,dog.h);
+      ctx.fillStyle='red';
+      for(let i=0;i<kidneys.length;i++){
+        const k=kidneys[i];
+        k.y+=3;
+        ctx.fillRect(k.x,k.y,10,15);
+        if(k.y>canvas.height){ kidneys.splice(i,1); i--; continue; }
+        if(k.x<dog.x+dog.w && k.x+10>dog.x && k.y<dog.y+dog.h && k.y+15>dog.y){
+          kidneys.splice(i,1); i--; score++; }
+      }
+      ctx.fillStyle='black';
+      ctx.font='16px sans-serif';
+      ctx.fillText('Score:'+score,10,20);
+      ctx.fillText('Time:'+time, canvas.width-80,20);
+    }
+    function countdown(){
+      time--; document.getElementById('status').textContent='Score: '+score+' | Time: '+time;
+      if(time<=0){ clearInterval(timer); clearInterval(loop); clearInterval(spawner); alert('Final score: '+score); }
+    }
+    const loop=setInterval(update,50);
+    const spawner=setInterval(spawnKidney,800);
+    const timer=setInterval(countdown,1000);
+  </script>
+  <p><a href="index.html">Back</a></p>
+</body>
+</html>

--- a/web_games/parasite_pop.html
+++ b/web_games/parasite_pop.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Parasite Pop</title>
+  <style>
+    body { text-align: center; font-family: sans-serif; background:#fffbe0; }
+    canvas { border:1px solid #ccc; display:block; margin:10px auto; background:#ffffe8; }
+  </style>
+</head>
+<body>
+  <h1>Parasite Pop</h1>
+  <canvas id="game" width="400" height="400"></canvas>
+  <p id="status">Score: 0 | Time: 30</p>
+  <script>
+    const canvas=document.getElementById('game');
+    const ctx=canvas.getContext('2d');
+    let bugs=[];
+    let score=0;
+    let time=30;
+    canvas.addEventListener('click',e=>{
+      const rect=canvas.getBoundingClientRect();
+      const x=e.clientX-rect.left;
+      const y=e.clientY-rect.top;
+      for(let i=0;i<bugs.length;i++){
+        const b=bugs[i];
+        const dx=x-b.x; const dy=y-b.y;
+        if(Math.sqrt(dx*dx+dy*dy)<b.r){ bugs.splice(i,1); i--; score++; }
+      }
+    });
+    function spawn(){
+      bugs.push({x:Math.random()*canvas.width,y:Math.random()*canvas.height,r:15,t:0});
+    }
+    function update(){
+      ctx.clearRect(0,0,canvas.width,canvas.height);
+      ctx.fillStyle='green';
+      for(let i=0;i<bugs.length;i++){
+        const b=bugs[i]; b.t++; if(b.t>100){ bugs.splice(i,1); i--; continue; }
+        ctx.beginPath(); ctx.arc(b.x,b.y,b.r,0,Math.PI*2); ctx.fill();
+      }
+      ctx.fillStyle='black'; ctx.font='16px sans-serif';
+      ctx.fillText('Score:'+score,10,20); ctx.fillText('Time:'+time,canvas.width-80,20);
+    }
+    function countdown(){ time--; document.getElementById('status').textContent='Score: '+score+' | Time: '+time; if(time<=0){ clearInterval(loop); clearInterval(spawner); clearInterval(timer); alert('Final score: '+score); }}
+    const loop=setInterval(update,50);
+    const spawner=setInterval(spawn,600);
+    const timer=setInterval(countdown,1000);
+  </script>
+  <p><a href="index.html">Back</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- integrate web-based mini games menu option in `main.py`
- launch web games via new `start_mini_games` helper
- expose `/mini-games` on the Flask web interface
- create three simple HTML5/JS games: **Feline Fever Finder**, **Canine Kidney Catch**, and **Parasite Pop**

## Testing
- `python -m py_compile main.py utilities/web_server.py`


------
https://chatgpt.com/codex/tasks/task_e_684b8240b594832fab7f9fe8b0fecae1