### PR TITLE
Add numeric shift screen for RDP keyboard

### DIFF
--- a/main.py
+++ b/main.py
@@ -2811,7 +2811,15 @@ KEYBOARD_PUNCT = [
     [" "]
 ]
 
-KEY_LAYOUTS = [KEYBOARD_UPPER, KEYBOARD_LOWER, KEYBOARD_PUNCT]
+# Numeric layout used as an additional shift state
+KEYBOARD_NUM = [
+    list("1234567890"),
+    list("-/:;()$&@\""),
+    list(".,?!'[]{}#"),
+    [" "]
+]
+
+KEY_LAYOUTS = [KEYBOARD_UPPER, KEYBOARD_LOWER, KEYBOARD_PUNCT, KEYBOARD_NUM]
 KEY_LAYOUT = KEY_LAYOUTS[keyboard_state]
 
 # IRC keyboard uses lower case by default


### PR DESCRIPTION
## Summary
- add a numeric keyboard layout
- include this new layout in the global shift states used by the RDP utility

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_684fdd529744832f9c214337608efd2a