### PR TITLE
Add repo refresh utility

### DIFF
--- a/utilities/__init__.py
+++ b/utilities/__init__.py
@@ -1,2 +1,2 @@
-from . import web_server
-__all__ = ["web_server"]
+from . import web_server, update_repo
+__all__ = ["web_server", "update_repo"]

--- a/utilities/update_repo.py
+++ b/utilities/update_repo.py
@@ -1,0 +1,20 @@
+import os
+import shutil
+import subprocess
+
+
+def refresh_repo():
+    """Delete /mini_os and clone repo fresh."""
+    target = "/mini_os"
+    if os.path.isdir(target):
+        shutil.rmtree(target)
+    subprocess.run([
+        "git",
+        "clone",
+        "https://github.com/paulthomason/mini_os.git",
+        target,
+    ], check=True)
+
+
+if __name__ == "__main__":
+    refresh_repo()


### PR DESCRIPTION
## Summary
- add `update_repo` utility to delete /mini_os and clone the latest repo
- expose `update_repo` module in utilities package

## Testing
- `python3 -m py_compile utilities/update_repo.py`


------
https://chatgpt.com/codex/tasks/task_e_685081d10e00832f8d461d0f6c94e81b