### PR TITLE
Improve AI Cases instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The service definition will start the program on boot and restart it automatical
 
 The menu can fetch headlines from the New York Times API. Copy `nyt_config.py.example` to `nyt_config.py` and add your API key. The file is in `.gitignore` so your key stays local.
 
-An additional `openai_config.py.example` provides a placeholder for your OpenAI API key. Copy it to `openai_config.py` and enter your key to enable the AI‑powered **AI Cases** game. The AI narrates a day in veterinary internal medicine and offers three numbered choices that you select using the hardware buttons.
+An additional `openai_config.py.example` provides a placeholder for your OpenAI API key. Copy it to `openai_config.py` and enter your key to enable the AI‑powered **AI Cases** game. The AI narrates a day in veterinary internal medicine and offers three short numbered choices describing what you can do next. Select your option using the hardware buttons.
 
 ## Web Interface
 

--- a/games/ai_cases.py
+++ b/games/ai_cases.py
@@ -70,11 +70,11 @@ def request_chat(message):
                         "content": (
                             "You are narrating a typical day as a veterinary internal "
                             "medicine specialist. After each scenario respond only with "
-                            "valid JSON containing keys 'reply' and 'options'. The reply "
-                            "is a short description of the next situation. The options "
-                            "array must contain exactly three short numbered choices (1, 2, 3) "
-                            "that the user can select to decide what to do next. Use the user's "
-                            "previous choice to generate the following scenario."
+                            "valid JSON containing keys 'reply' and 'options'. The 'reply' "
+                            "is a short description of the next situation. The 'options' "
+                            "array must contain exactly three brief descriptions of actions "
+                            "the user can take, each prefixed with its number (1, 2, 3). "
+                            "Use the user's previous choice to generate the following scenario."
                         ),
                     }
                 ]


### PR DESCRIPTION
## Summary
- tweak system prompt in `games/ai_cases.py` so OpenAI returns three descriptive numbered choices
- update README to mention choices describe actions

## Testing
- `python3 -m py_compile games/ai_cases.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509347a850832f968bb022cc527154