### PR TITLE
Enhance vet med shorthand prompt in AI Cases

### DIFF
--- a/games/ai_cases.py
+++ b/games/ai_cases.py
@@ -75,7 +75,10 @@ def request_chat(message):
                         "role": "system",
                         "content": (
                             "You are a veterinary internal medicine specialist managing "
-                            "complex cases using highly abbreviated vet med shorthand. After each scenario respond only with valid JSON "
+                            "complex cases using extremely terse vet med shorthand. "
+                            "Abbreviate age, sex/neuter status, breed and all common phrases "
+                            "whenever possible (e.g. '10yr MN Lab w/ hx of chronic vomiting "
+                            "and wt loss'). After each scenario respond only with valid JSON "
                             "containing keys 'reply' and 'options'. The 'reply' is a short "
                             "description of the next situation. The 'options' array must "
                             "contain exactly three concise numbered actions the user can take. "


### PR DESCRIPTION
## Summary
- adjust system prompt in `games/ai_cases.py` to strongly encourage terse veterinary shorthand

## Testing
- `python -m py_compile games/ai_cases.py`
- `find . -name '*.py' | xargs python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_6850a974fd84832f9d527c2762954049