### PR TITLE
Add joystick hold exit for AI Cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The service definition will start the program on boot and restart it automatical
 The menu can fetch headlines from the New York Times API. Copy `nyt_config.py.example` to `nyt_config.py` and add your API key. The file is in `.gitignore` so your key stays local.
 
 An additional `openai_config.py.example` provides a placeholder for your OpenAI API key. Copy it to `openai_config.py` and enter your key to enable the AI‑powered **AI Cases** game. The AI narrates a day in veterinary internal medicine and offers three short numbered choices describing what you can do next. Select your option using the hardware buttons.
+To leave the game at any time, hold the joystick to the left for about a second and you'll return to the main menu.
 
 ## Web Interface
 

--- a/main.py
+++ b/main.py
@@ -978,6 +978,9 @@ def button_event_handler(channel):
         ):
             if hold_time >= 1:
                 show_console_color_scheme_menu()
+        elif menu_instance.current_screen == "ai_cases" and pin_name == "JOY_LEFT":
+            if hold_time >= 1:
+                show_main_menu()
         # print(f"[{datetime.now().strftime('%H:%M:%S')}] {pin_name} RELEASED.") # For debugging
     
     last_event_time[pin_name] = current_time


### PR DESCRIPTION
## Summary
- exit AI Cases when holding the joystick left
- note joystick-left exit in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6850aac610d8832fbb15e014dd656b8b