### PR TITLE
Fix README merge conflict and clarify key usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,9 @@ The service definition will start the program on boot and restart it automatical
 
 The menu can fetch headlines from the New York Times API. Copy `nyt_config.py.example` to `nyt_config.py` and add your API key. The file is in `.gitignore` so your key stays local.
 
-An additional `openai_config.py.example` provides a placeholder for your OpenAI API key. Copy it to `openai_config.py` and enter your key to enable the AI‑powered **AI Cases** game. The AI narrates a day in veterinary internal medicine and offers three short numbered choices describing what you can do next. Select your option using the hardware buttons.
-<<<<<<< codex/return-to-main-menu-on-joystick-hold
+An additional `openai_config.py.example` provides a placeholder for your OpenAI API key. Copy it to `openai_config.py` and enter your key to enable the AI‑powered **AI Cases** game. The AI narrates a day in veterinary internal medicine and offers three short numbered choices describing what you can do next. Select your option using the hardware buttons. The same key now powers **Vet Adventure**, a lighthearted text adventure set in a bustling clinic.
+
 To leave the game at any time, hold the joystick to the left for about a second and you'll return to the main menu.
-=======
-The same key now powers **Vet Adventure**, a lighthearted text adventure set in a bustling clinic.
->>>>>>> main
 
 ## Web Interface
 


### PR DESCRIPTION
## Summary
- resolve merge conflict markers in README
- mention that Vet Adventure uses the same OpenAI key as AI Cases
- include the joystick hold hint for exiting games

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850c5578584832faff9c52516d26954