### PR TITLE
Add env var fallback for OpenAI keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The service definition will start the program on boot and restart it automatical
 
 The menu can fetch headlines from the New York Times API. Copy `nyt_config.py.example` to `nyt_config.py` and add your API key. The file is in `.gitignore` so your key stays local.
 
-An additional `openai_config.py.example` provides a placeholder for your OpenAI API key. Copy it to `openai_config.py` and enter your key to enable the AI‑powered **AI Cases** game. The AI narrates a day in veterinary internal medicine and offers three short numbered choices describing what you can do next. Select your option using the hardware buttons. The same key now powers **Vet Adventure**, a lighthearted text adventure set in a bustling clinic.
+An additional `openai_config.py.example` provides a placeholder for your OpenAI API key. Copy it to `openai_config.py` and enter your key or set the `OPENAI_API_KEY` environment variable to enable the AI‑powered **AI Cases** game. The AI narrates a day in veterinary internal medicine and offers three short numbered choices describing what you can do next. The same key now powers **Vet Adventure**, a lighthearted text adventure set in a bustling clinic. Setting `VA_OPENAI_API_KEY` will override the general key for Vet Adventure if desired.
 
 To leave the game at any time, hold the joystick to the left for about a second and you'll return to the main menu.
 

--- a/games/ai_cases.py
+++ b/games/ai_cases.py
@@ -48,12 +48,20 @@ line_height = 0
 
 
 def load_api_key():
+    """Load the OpenAI API key from env vars or config."""
     global OPENAI_API_KEY
     log("Loading API key", reset=False)
+
+    env_key = os.environ.get("OPENAI_API_KEY")
+    if env_key:
+        OPENAI_API_KEY = env_key
+        log("Loaded API key from environment")
+        return
+
     try:
         from openai_config import OPENAI_API_KEY as KEY
         OPENAI_API_KEY = KEY
-        log("Loaded API key successfully")
+        log("Loaded API key from file")
     except Exception as e:
         OPENAI_API_KEY = None
         log(f"Failed to load API key: {e}")

--- a/games/vet_adventure.py
+++ b/games/vet_adventure.py
@@ -34,7 +34,16 @@ def log(msg, *, reset=False):
         pass
 
 def load_api_key():
+    """Populate OPENAI_API_KEY from env vars or config files."""
     global OPENAI_API_KEY
+
+    # Environment variable takes precedence so deployments can avoid
+    # storing secrets in source control.
+    env_key = os.environ.get("VA_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
+    if env_key:
+        OPENAI_API_KEY = env_key
+        return
+
     try:
         from vet_openai_config import VA_OPENAI_API_KEY as KEY
         OPENAI_API_KEY = KEY

--- a/openai_config.py.example
+++ b/openai_config.py.example
@@ -1,2 +1,9 @@
-OPENAI_API_KEY = "YOUR_API_KEY_HERE"
-VA_OPENAI_API_KEY = "YOUR_API_KEY_HERE"
+import os
+
+# Attempt to read the keys from environment variables so the game can run
+# without editing this file.  If the variables are not set, fall back to the
+# placeholder strings.  Copy this file to `openai_config.py` and replace the
+# placeholders or set the environment variables before launching the program.
+
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "YOUR_API_KEY_HERE")
+VA_OPENAI_API_KEY = os.environ.get("VA_OPENAI_API_KEY", OPENAI_API_KEY)

--- a/utilities/web_server.py
+++ b/utilities/web_server.py
@@ -73,8 +73,14 @@ def load_nyt_api_key():
         NYT_API_KEY = "YOUR_API_KEY_HERE"
 
 def load_openai_api_key():
-    """Try to load OpenAI API key from openai_config.py"""
+    """Try to load OpenAI API key from env var or openai_config.py"""
     global OPENAI_API_KEY
+
+    env_key = os.environ.get("OPENAI_API_KEY")
+    if env_key:
+        OPENAI_API_KEY = env_key
+        return
+
     try:
         from openai_config import OPENAI_API_KEY as KEY
         OPENAI_API_KEY = KEY
@@ -82,8 +88,14 @@ def load_openai_api_key():
         OPENAI_API_KEY = "YOUR_API_KEY_HERE"
 
 def load_va_openai_api_key():
-    """Try to load Vet Adventure OpenAI key from vet_openai_config.py."""
+    """Try to load Vet Adventure OpenAI key from env var or vet_openai_config.py."""
     global VA_OPENAI_API_KEY
+
+    env_key = os.environ.get("VA_OPENAI_API_KEY")
+    if env_key:
+        VA_OPENAI_API_KEY = env_key
+        return
+
     try:
         from vet_openai_config import VA_OPENAI_API_KEY as KEY
         VA_OPENAI_API_KEY = KEY

--- a/vet_openai_config.py.example
+++ b/vet_openai_config.py.example
@@ -1,1 +1,8 @@
-VA_OPENAI_API_KEY = "YOUR_API_KEY_HERE"
+import os
+
+# This configuration file is optional.  The Vet Adventure game will also look
+# for the `VA_OPENAI_API_KEY` environment variable.  Copy this file to
+# `vet_openai_config.py` and replace the placeholder below or set the
+# environment variable.
+
+VA_OPENAI_API_KEY = os.environ.get("VA_OPENAI_API_KEY", "YOUR_API_KEY_HERE")


### PR DESCRIPTION
## Summary
- allow OpenAI API keys to be loaded from environment variables
- document environment variables in README
- update example config files for env var use

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851c1e2ea90832fb68c5de584c2162a