### PR TITLE
Update Vet Adventure API key loading

### DIFF
--- a/games/vet_adventure.py
+++ b/games/vet_adventure.py
@@ -5,6 +5,7 @@ import openai
 from datetime import datetime
 from PIL import Image, ImageDraw
 from .trivia import wrap_text
+import importlib.util
 
 thread_safe_display = None
 fonts = None
@@ -34,12 +35,15 @@ def log(msg, *, reset=False):
         pass
 
 def load_api_key():
-    """Load the API key from openai_config.py."""
+    """Load the API key from openai_config.py in the mini_os directory."""
     global OPENAI_API_KEY
 
+    config_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "openai_config.py")
     try:
-        from openai_config import OPENAI_API_KEY as KEY
-        OPENAI_API_KEY = KEY
+        spec = importlib.util.spec_from_file_location("openai_config", config_path)
+        cfg = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cfg)
+        OPENAI_API_KEY = getattr(cfg, "OPENAI_API_KEY", None)
     except Exception as e:
         OPENAI_API_KEY = None
         log(f"API key load failed: {e}")


### PR DESCRIPTION
## Summary
- load Vet Adventure's OpenAI key from `openai_config.py`

## Testing
- `python3 -m py_compile games/vet_adventure.py`
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68523890f364832fa2854e10f5f70362