### PR TITLE
Add joystick hold exit for Vet Adventure

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ An additional `openai_config.py.example` provides a placeholder for your OpenAI 
 
 The system prompt used for **AI Cases** is stored in `systemprompt.txt` at the repository root. Edit that file to change the instructions without modifying the code.
 
-To leave the game at any time, hold the joystick to the left for about a second and you'll return to the main menu.
+To leave the AI Cases or Vet Adventure game at any time, hold the joystick to the left for about a second and you'll return to the main menu.
 
 ## Web Interface
 

--- a/main.py
+++ b/main.py
@@ -994,6 +994,9 @@ def button_event_handler(channel):
         elif menu_instance.current_screen == "ai_cases" and pin_name == "JOY_LEFT":
             if hold_time >= 1:
                 show_main_menu()
+        elif menu_instance.current_screen == "vet_adventure" and pin_name == "JOY_LEFT":
+            if hold_time >= 1:
+                show_main_menu()
         # print(f"[{datetime.now().strftime('%H:%M:%S')}] {pin_name} RELEASED.") # For debugging
     
     last_event_time[pin_name] = current_time


### PR DESCRIPTION
## Summary
- enable returning to the main menu from Vet Adventure by holding the joystick left for a second
- document this exit method in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6852cd832548832f81a3c7d33653cd55